### PR TITLE
Add Travis build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-GOV.UK Frontend Alpha
+GOV.UK Frontend Alpha [![Build Status](https://travis-ci.org/alphagov/govuk_frontend_alpha.svg?branch=master)](https://travis-ci.org/alphagov/govuk_frontend_alpha)
 =====================
 
 ---


### PR DESCRIPTION
This will display a [Travis status image](https://docs.travis-ci.com/user/status-images/) next to the repo name.
