### PR TITLE
Add an unbranded template

### DIFF
--- a/app/templates/govuk_template.html
+++ b/app/templates/govuk_template.html
@@ -80,7 +80,7 @@
           </div>
 
           <div class="copyright">
-            <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">{{ crown_copyright_message|default('&copy; Crown copyright')|safe }}</a>
+            <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">{{ crown_copyright_message|default('© Crown copyright') }}</a>
           </div>
         </div>
       </div>

--- a/app/templates/govuk_template.html
+++ b/app/templates/govuk_template.html
@@ -40,12 +40,7 @@
       </div>
     </div>
 
-    <div id="global-cookie-message">
-
-        {% block cookie_message %}{% endblock %}
-
-    </div>
-
+    <div id="global-cookie-message">{% block cookie_message %}{% endblock %}</div>
 
     <header role="banner" id="global-header" class="{% block header_class %}{% endblock %}">
       <div class="header-wrapper">
@@ -60,7 +55,6 @@
         {% block proposition_header %}{% endblock %}
       </div>
     </header>
-
 
     {% block after_header %}{% endblock %}
 

--- a/app/templates/govuk_template.html
+++ b/app/templates/govuk_template.html
@@ -6,25 +6,25 @@
     <meta charset="utf-8" />
     <title>{% block page_title %}GOV.UK - The best place to find government services and information{% endblock %}</title>
 
-    <!--[if gt IE 8]><!--><link href="{{ asset_path + 'stylesheets/govuk-template.css?0.18.2' }}" media="screen" rel="stylesheet" /><!--<![endif]-->
-    <!--[if IE 6]><link href="{{ asset_path + 'stylesheets/govuk-template-ie6.css?0.18.2' }}" media="screen" rel="stylesheet" /><![endif]-->
-    <!--[if IE 7]><link href="{{ asset_path + 'stylesheets/govuk-template-ie7.css?0.18.2' }}" media="screen" rel="stylesheet" /><![endif]-->
-    <!--[if IE 8]><link href="{{ asset_path + 'stylesheets/govuk-template-ie8.css?0.18.2' }}" media="screen" rel="stylesheet" /><![endif]-->
-    <link href="{{ asset_path + 'stylesheets/govuk-template-print.css?0.18.2' }}" media="print" rel="stylesheet" />
+    <!--[if gt IE 8]><!--><link href="{{ asset_path + 'stylesheets/govuk-template.css' }}" media="screen" rel="stylesheet" /><!--<![endif]-->
+    <!--[if IE 6]><link href="{{ asset_path + 'stylesheets/govuk-template-ie6.css' }}" media="screen" rel="stylesheet" /><![endif]-->
+    <!--[if IE 7]><link href="{{ asset_path + 'stylesheets/govuk-template-ie7.css' }}" media="screen" rel="stylesheet" /><![endif]-->
+    <!--[if IE 8]><link href="{{ asset_path + 'stylesheets/govuk-template-ie8.css' }}" media="screen" rel="stylesheet" /><![endif]-->
+    <link href="{{ asset_path + 'stylesheets/govuk-template-print.css' }}" media="print" rel="stylesheet" />
 
-    <!--[if IE 8]><link href="{{ asset_path + 'stylesheets/fonts-ie8.css?0.18.2' }}" media="all" rel="stylesheet" /><![endif]-->
-    <!--[if gte IE 9]><!--><link href="{{ asset_path + 'stylesheets/fonts.css?0.18.2' }}" media="all" rel="stylesheet" /><!--<![endif]-->
-    <!--[if lt IE 9]><script src="{{ asset_path + 'javascripts/ie.js?0.18.2' }}"></script><![endif]-->
+    <!--[if IE 8]><link href="{{ asset_path + 'stylesheets/fonts-ie8.css' }}" media="all" rel="stylesheet" /><![endif]-->
+    <!--[if gte IE 9]><!--><link href="{{ asset_path + 'stylesheets/fonts.css' }}" media="all" rel="stylesheet" /><!--<![endif]-->
+    <!--[if lt IE 9]><script src="{{ asset_path + 'javascripts/ie.js' }}"></script><![endif]-->
 
-    <link rel="shortcut icon" href="{{ asset_path + 'images/favicon.ico?0.18.2' }}" type="image/x-icon" />
-    <link rel="mask-icon" href="{{ asset_path + 'images/gov.uk_logotype_crown.svg?0.18.2' }}" color="#0b0c0c">
-    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ asset_path + 'images/apple-touch-icon-152x152.png?0.18.2' }}">
-    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{ asset_path + 'images/apple-touch-icon-120x120.png?0.18.2' }}">
-    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="{{ asset_path + 'images/apple-touch-icon-76x76.png?0.18.2' }}">
-    <link rel="apple-touch-icon-precomposed" href="{{ asset_path + 'images/apple-touch-icon-60x60.png?0.18.2' }}">
+    <link rel="shortcut icon" href="{{ asset_path + 'images/favicon.ico' }}" type="image/x-icon" />
+    <link rel="mask-icon" href="{{ asset_path + 'images/gov.uk_logotype_crown.svg' }}" color="#0b0c0c">
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ asset_path + 'images/apple-touch-icon-152x152.png' }}">
+    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{ asset_path + 'images/apple-touch-icon-120x120.png' }}">
+    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="{{ asset_path + 'images/apple-touch-icon-76x76.png' }}">
+    <link rel="apple-touch-icon-precomposed" href="{{ asset_path + 'images/apple-touch-icon-60x60.png' }}">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property="og:image" content="{{ asset_path + 'images/opengraph-image.png?0.18.2' }}">
+    <meta property="og:image" content="{{ asset_path + 'images/opengraph-image.png' }}">
 
     {% block head %}{% endblock %}
   </head>
@@ -47,7 +47,7 @@
         <div class="header-global">
           <div class="header-logo">
             <a href="{{ homepage_url|default('https://www.gov.uk') }}" title="{{ logo_link_title|default('Go to the GOV.UK homepage') }}" id="logo" class="content">
-              <img src="{{ asset_path + 'images/gov.uk_logotype_crown_invert_trans.png?0.18.2' }}" width="35" height="31" alt=""> {{ global_header_text|default('GOV.UK') }}
+              <img src="{{ asset_path + 'images/gov.uk_logotype_crown_invert_trans.png' }}" width="35" height="31" alt=""> {{ global_header_text|default('GOV.UK') }}
             </a>
           </div>
           {% block inside_header %}{% endblock %}
@@ -88,7 +88,7 @@
 
     <div id="global-app-error" class="app-error hidden"></div>
 
-    <script src="{{ asset_path + 'javascripts/govuk-template.js?0.18.2' }}"></script>
+    <script src="{{ asset_path + 'javascripts/govuk-template.js' }}"></script>
 
     {% block body_end %}{% endblock %}
 

--- a/app/templates/unbranded_template.html
+++ b/app/templates/unbranded_template.html
@@ -6,24 +6,24 @@
     <meta charset="utf-8" />
     <title>{% block page_title %}{% endblock %}</title>
 
-    <!--[if gt IE 8]><!--><link href="{{ asset_path + 'stylesheets/govuk-template.css?0.18.2' }}" media="screen" rel="stylesheet" /><!--<![endif]-->
-    <!--[if IE 6]><link href="{{ asset_path + 'stylesheets/govuk-template-ie6.css?0.18.2' }}" media="screen" rel="stylesheet" /><![endif]-->
-    <!--[if IE 7]><link href="{{ asset_path + 'stylesheets/govuk-template-ie7.css?0.18.2' }}" media="screen" rel="stylesheet" /><![endif]-->
-    <!--[if IE 8]><link href="{{ asset_path + 'stylesheets/govuk-template-ie8.css?0.18.2' }}" media="screen" rel="stylesheet" /><![endif]-->
-    <link href="{{ asset_path + 'stylesheets/govuk-template-print.css?0.18.2' }}" media="print" rel="stylesheet" />
+    <!--[if gt IE 8]><!--><link href="{{ asset_path + 'stylesheets/govuk-template.css' }}" media="screen" rel="stylesheet" /><!--<![endif]-->
+    <!--[if IE 6]><link href="{{ asset_path + 'stylesheets/govuk-template-ie6.css' }}" media="screen" rel="stylesheet" /><![endif]-->
+    <!--[if IE 7]><link href="{{ asset_path + 'stylesheets/govuk-template-ie7.css' }}" media="screen" rel="stylesheet" /><![endif]-->
+    <!--[if IE 8]><link href="{{ asset_path + 'stylesheets/govuk-template-ie8.css' }}" media="screen" rel="stylesheet" /><![endif]-->
+    <link href="{{ asset_path + 'stylesheets/govuk-template-print.css' }}" media="print" rel="stylesheet" />
 
-    <!--[if IE 8]><link href="{{ asset_path + 'stylesheets/fonts-ie8.css?0.18.2' }}" media="all" rel="stylesheet" /><![endif]-->
-    <!--[if gte IE 9]><!--><link href="{{ asset_path + 'stylesheets/fonts.css?0.18.2' }}" media="all" rel="stylesheet" /><!--<![endif]-->
-    <!--[if lt IE 9]><script src="{{ asset_path + 'javascripts/ie.js?0.18.2' }}"></script><![endif]-->
+    <!--[if IE 8]><link href="{{ asset_path + 'stylesheets/fonts-ie8.css' }}" media="all" rel="stylesheet" /><![endif]-->
+    <!--[if gte IE 9]><!--><link href="{{ asset_path + 'stylesheets/fonts.css' }}" media="all" rel="stylesheet" /><!--<![endif]-->
+    <!--[if lt IE 9]><script src="{{ asset_path + 'javascripts/ie.js' }}"></script><![endif]-->
 
-    <link rel="shortcut icon" href="{{ asset_path + 'images/favicon.ico?0.18.2' }}" type="image/x-icon" />
-    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ asset_path + 'images/apple-touch-icon-152x152.png?0.18.2' }}">
-    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{ asset_path + 'images/apple-touch-icon-120x120.png?0.18.2' }}">
-    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="{{ asset_path + 'images/apple-touch-icon-76x76.png?0.18.2' }}">
-    <link rel="apple-touch-icon-precomposed" href="{{ asset_path + 'images/apple-touch-icon-60x60.png?0.18.2' }}">
+    <link rel="shortcut icon" href="{{ asset_path + 'images/favicon.ico' }}" type="image/x-icon" />
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ asset_path + 'images/apple-touch-icon-152x152.png' }}">
+    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{ asset_path + 'images/apple-touch-icon-120x120.png' }}">
+    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="{{ asset_path + 'images/apple-touch-icon-76x76.png' }}">
+    <link rel="apple-touch-icon-precomposed" href="{{ asset_path + 'images/apple-touch-icon-60x60.png' }}">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property="og:image" content="{{ asset_path + 'images/opengraph-image.png?0.18.2' }}">
+    <meta property="og:image" content="{{ asset_path + 'images/opengraph-image.png' }}">
 
     {% block head %}{% endblock %}
   </head>
@@ -66,7 +66,7 @@
 
     <div id="global-app-error" class="app-error hidden"></div>
 
-    <script src="{{ asset_path + 'javascripts/govuk-template.js?0.18.2' }}"></script>
+    <script src="{{ asset_path + 'javascripts/govuk-template.js' }}"></script>
 
     {% block body_end %}{% endblock %}
 

--- a/app/templates/unbranded_template.html
+++ b/app/templates/unbranded_template.html
@@ -39,22 +39,22 @@
       </div>
     </div>
 
-    <div id="global-cookie-message">
-
-        {% block cookie_message %}{% endblock %}
-
-    </div>
+    <div id="global-cookie-message">{% block cookie_message %}{% endblock %}</div>
 
 
     <header role="banner" id="global-header" class="{% block header_class %}{% endblock %}">
       <div class="header-wrapper">
         <div class="header-global">
+          <div class="header-logo">
+            <a href="{{ homepage_url|default('#') }}" title="{{ logo_link_title|default('Go to the service homepage') }}" id="logo" class="content">
+              {{ global_header_text|default('Service title') }}
+            </a>
+          </div>
           {% block inside_header %}{% endblock %}
         </div>
         {% block proposition_header %}{% endblock %}
       </div>
     </header>
-
 
     {% block after_header %}{% endblock %}
 

--- a/app/templates/unbranded_template.html
+++ b/app/templates/unbranded_template.html
@@ -1,0 +1,77 @@
+{% block top_of_page %}{% endblock %}
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="lte-ie8" lang="{{ html_lang|default('en') }}"><![endif]-->
+<!--[if gt IE 8]><!--><html lang="{{ html_lang|default('en') }}"><!--<![endif]-->
+  <head>
+    <meta charset="utf-8" />
+    <title>{% block page_title %}{% endblock %}</title>
+
+    <!--[if gt IE 8]><!--><link href="{{ asset_path + 'stylesheets/govuk-template.css?0.18.2' }}" media="screen" rel="stylesheet" /><!--<![endif]-->
+    <!--[if IE 6]><link href="{{ asset_path + 'stylesheets/govuk-template-ie6.css?0.18.2' }}" media="screen" rel="stylesheet" /><![endif]-->
+    <!--[if IE 7]><link href="{{ asset_path + 'stylesheets/govuk-template-ie7.css?0.18.2' }}" media="screen" rel="stylesheet" /><![endif]-->
+    <!--[if IE 8]><link href="{{ asset_path + 'stylesheets/govuk-template-ie8.css?0.18.2' }}" media="screen" rel="stylesheet" /><![endif]-->
+    <link href="{{ asset_path + 'stylesheets/govuk-template-print.css?0.18.2' }}" media="print" rel="stylesheet" />
+
+    <!--[if IE 8]><link href="{{ asset_path + 'stylesheets/fonts-ie8.css?0.18.2' }}" media="all" rel="stylesheet" /><![endif]-->
+    <!--[if gte IE 9]><!--><link href="{{ asset_path + 'stylesheets/fonts.css?0.18.2' }}" media="all" rel="stylesheet" /><!--<![endif]-->
+    <!--[if lt IE 9]><script src="{{ asset_path + 'javascripts/ie.js?0.18.2' }}"></script><![endif]-->
+
+    <link rel="shortcut icon" href="{{ asset_path + 'images/favicon.ico?0.18.2' }}" type="image/x-icon" />
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ asset_path + 'images/apple-touch-icon-152x152.png?0.18.2' }}">
+    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{ asset_path + 'images/apple-touch-icon-120x120.png?0.18.2' }}">
+    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="{{ asset_path + 'images/apple-touch-icon-76x76.png?0.18.2' }}">
+    <link rel="apple-touch-icon-precomposed" href="{{ asset_path + 'images/apple-touch-icon-60x60.png?0.18.2' }}">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta property="og:image" content="{{ asset_path + 'images/opengraph-image.png?0.18.2' }}">
+
+    {% block head %}{% endblock %}
+  </head>
+
+  <body class="{% block body_classes %}{% endblock %}">
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+
+    {% block body_start %}{% endblock %}
+
+    <div id="skiplink-container">
+      <div>
+        <a href="#content" class="skiplink">{{ skip_link_message|default('Skip to main content') }}</a>
+      </div>
+    </div>
+
+    <div id="global-cookie-message">
+
+        {% block cookie_message %}{% endblock %}
+
+    </div>
+
+
+    <header role="banner" id="global-header" class="{% block header_class %}{% endblock %}">
+      <div class="header-wrapper">
+        <div class="header-global">
+          {% block inside_header %}{% endblock %}
+        </div>
+        {% block proposition_header %}{% endblock %}
+      </div>
+    </header>
+
+
+    {% block after_header %}{% endblock %}
+
+    <div id="global-header-bar"></div>
+
+    {% block content %}{% endblock %}
+
+    <footer class="group js-footer" id="footer" role="contentinfo"></footer>
+
+    <div id="global-app-error" class="app-error hidden"></div>
+
+    <script src="{{ asset_path + 'javascripts/govuk-template.js?0.18.2' }}"></script>
+
+    {% block body_end %}{% endblock %}
+
+
+    <script>if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');</script>
+  </body>
+</html>
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,14 +30,14 @@ gulp.task('copy:prototype-scss-refactor', () => {
 
 // Task for transpiling the templates
 let transpileRunner = templateLanguage => {
-  return gulp.src(paths.templates + 'govuk_template.html')
+  return gulp.src(paths.templates + '*.html')
     .pipe(transpiler(templateLanguage))
     .pipe(rename({extname: '.html.' + templateLanguage}))
     .pipe(gulp.dest(paths.dist))
 }
 gulp.task('transpile', ['transpile:nunjucks', 'transpile:erb', 'transpile:handlebars', 'transpile:django'])
 gulp.task('transpile:nunjucks', () => {
-  return gulp.src(paths.templates + 'govuk_template.html')
+  return gulp.src(paths.templates + '*.html')
     .pipe(rename({extname: '.html.nunjucks'}))
     .pipe(gulp.dest(paths.dist))
 })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const packageJson = require('./package.json')
+const version = packageJson.version
+
 const gulp = require('gulp')
 const del = require('del')
 const rename = require('gulp-rename')
@@ -31,7 +34,7 @@ gulp.task('copy:prototype-scss-refactor', () => {
 // Task for transpiling the templates
 let transpileRunner = templateLanguage => {
   return gulp.src(paths.templates + '*.html')
-    .pipe(transpiler(templateLanguage))
+    .pipe(transpiler(templateLanguage, version))
     .pipe(rename({extname: '.html.' + templateLanguage}))
     .pipe(gulp.dest(paths.dist))
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,12 +12,12 @@ const mocha = require('gulp-mocha')
 // Config for paths
 const paths = {
   assets: 'app/assets/',
-  assets_scss: 'app/assets/scss/',
+  assetsScss: 'app/assets/scss/',
   dist: 'dist/',
   templates: 'app/templates/',
   npm: 'node_modules/',
   specs: 'test/specs/',
-  prototype_scss: 'node_modules/@gemmaleigh/prototype-scss-refactor/**/*.scss' // This can be removed later
+  prototypeScss: 'node_modules/@gemmaleigh/prototype-scss-refactor/**/*.scss' // This can be removed later
 }
 
 // Task for cleaning the distribution
@@ -27,8 +27,8 @@ gulp.task('clean', () => {
 
 // Task for copying the assets
 gulp.task('copy:prototype-scss-refactor', () => {
-  gulp.src(paths.prototype_scss)
-    .pipe(gulp.dest(paths.assets_scss))
+  gulp.src(paths.prototypeScss)
+    .pipe(gulp.dest(paths.assetsScss))
 })
 
 // Task for transpiling the templates

--- a/lib/transpilation/django_transpiler.js
+++ b/lib/transpilation/django_transpiler.js
@@ -2,7 +2,7 @@
 
 // Django templates for Python
 
-const asset_path = asset => `{% static '${asset}' %}`
+const asset_path = (asset, version) => `{% static '${asset}?${version}' %}`
 const block_for = (key, defaultContent = '') => `{% block ${key} %}${defaultContent}{% endblock %}`
 const text_for = (key, defaultContent = '') => `{{ ${key}|default:'${defaultContent}' }}`
 

--- a/lib/transpilation/erb_transpiler.js
+++ b/lib/transpilation/erb_transpiler.js
@@ -2,7 +2,10 @@
 
 // ERB templates for Ruby
 
-const asset_path = asset => `<%= asset_path '${asset}' %>`
+const asset_path = asset => {
+  asset = asset.replace(/^stylesheets\/|javascript\/|images\//, '')
+  return `<%= asset_path '${asset}' %>`
+}
 const block_for = (key, defaultContent = '') => {
   if (key === 'content') {
     // ERB needs a default yield

--- a/lib/transpilation/erb_transpiler.js
+++ b/lib/transpilation/erb_transpiler.js
@@ -11,7 +11,7 @@ const block_for = (key, defaultContent = '') => {
     // ERB needs a default yield
     return '<%= content_for?(:content) ? yield(:content) : yield %>'
   } else {
-    return `<%= content_for?(:${key}) ? yield(:${key}) : '${defaultContent}' %>`
+    return `<%= content_for?(:${key}) ? yield(:${key}) : '${defaultContent}'.html_safe %>`
   }
 }
 const text_for = (key, defaultContent = '') => block_for(key, defaultContent)

--- a/lib/transpilation/erb_transpiler.js
+++ b/lib/transpilation/erb_transpiler.js
@@ -2,9 +2,9 @@
 
 // ERB templates for Ruby
 
-const asset_path = asset => {
+const asset_path = (asset, version) => {
   asset = asset.replace(/^stylesheets\/|javascript\/|images\//, '')
-  return `<%= asset_path '${asset}' %>`
+  return `<%= asset_path '${asset}?${version}' %>`
 }
 const block_for = (key, defaultContent = '') => {
   if (key === 'content') {

--- a/lib/transpilation/handlebars_transpiler.js
+++ b/lib/transpilation/handlebars_transpiler.js
@@ -3,7 +3,7 @@
 // Handlebars templates
 // http://handlebarsjs.com/
 
-const asset_path = asset => `{{{ asset_path }}}${asset}`
+const asset_path = (asset, version) => `{{{ asset_path }}}${asset}?${version}`
 const block_for = (key, defaultContent = '') => `{{#if ${key}}}{{{ ${key} }}}{{else}}${defaultContent}{{/if}}`
 const text_for = (key, defaultContent = '') => block_for(key, defaultContent)
 

--- a/lib/transpilation/transpiler.js
+++ b/lib/transpilation/transpiler.js
@@ -8,18 +8,16 @@ const blockForPattern = /\{\% block (.*?) \%\}(.*?)\{\% endblock \%\}/
 
 const transpilationPattern = new RegExp([assetPathPattern.source, textForPattern.source, blockForPattern.source].join('|'), 'g')
 
-const transpile = target => {
+const transpile = (target, assetVersion) => {
   return through.obj((file, encoding, callback) => {
     if (file.isNull()) return callback(null, file)
-
     const targetTranspiler = require(`./${target}_transpiler.js`)
     let template = file.contents.toString(encoding)
-
     template = template.replace(transpilationPattern, function (match) {
       let replacement
       if (arguments[1] !== undefined) {
         // asset_path pattern
-        replacement = targetTranspiler.asset_path(arguments[1])
+        replacement = targetTranspiler.asset_path(arguments[1], assetVersion)
       } else if (arguments[2] !== undefined) {
         // text_for pattern
         replacement = targetTranspiler.text_for(arguments[2], arguments[3])

--- a/test/specs/transpiler_spec.js
+++ b/test/specs/transpiler_spec.js
@@ -14,13 +14,14 @@ const transpilationTest = function (transpiler, originalString, expectedString, 
 }
 
 const nunjucksAssetPath = `<link href="{{ asset_path + 'stylesheets/govuk-template.css' }}" media="screen" rel="stylesheet" />`
+const nunjucksAssetVersion = '1.0.0'
 const nunjucksTextFor = `<a href="#content" class="skiplink">{{ skip_link_message|default('Skip to main content') }}</a>`
 const nunjucksBlockFor = `{% block top_of_page %}{% endblock %}`
 
 describe('Transpilation', function () {
   it('should return a Buffer', function (done) {
     let inputFile = new File({contents: new Buffer('test')})
-    let testTranspiler = transpiler('erb')
+    let testTranspiler = transpiler('erb', nunjucksAssetVersion)
     testTranspiler.write(inputFile)
     testTranspiler.once('data', function (file) {
       expect(file.isBuffer()).to.equal(true)
@@ -32,21 +33,21 @@ describe('Transpilation', function () {
     let erbTranspiler
 
     beforeEach(function () {
-      erbTranspiler = transpiler('erb')
+      erbTranspiler = transpiler('erb', nunjucksAssetVersion)
     })
 
     it('should have a correct asset_path for stylesheets', function (done) {
-      const erbStylesheetsAssetPath = `<link href="<%= asset_path 'govuk-template.css' %>" media="screen" rel="stylesheet" />`
+      const erbStylesheetsAssetPath = `<link href="<%= asset_path 'govuk-template.css?1.0.0' %>" media="screen" rel="stylesheet" />`
       transpilationTest(erbTranspiler, nunjucksAssetPath, erbStylesheetsAssetPath, done)
     })
     it('should have a correct asset_path for javascript', function (done) {
       const nunjucksJavascriptAssetPath = `<script src="{{ asset_path + 'javascript/govuk-template.js' }}"></script>`
-      const erbJavascriptAssetPath = `<script src="<%= asset_path 'govuk-template.js' %>"></script>`
+      const erbJavascriptAssetPath = `<script src="<%= asset_path 'govuk-template.js?1.0.0' %>"></script>`
       transpilationTest(erbTranspiler, nunjucksJavascriptAssetPath, erbJavascriptAssetPath, done)
     })
     it('should have a correct asset_path for images', function (done) {
       const nunjucksImageAssetPath = `<img src="{{ asset_path + 'images/govuk-template.png' }}" alt="" />`
-      const erbImageAssetPath = `<img src="<%= asset_path 'govuk-template.png' %>" alt="" />`
+      const erbImageAssetPath = `<img src="<%= asset_path 'govuk-template.png?1.0.0' %>" alt="" />`
       transpilationTest(erbTranspiler, nunjucksImageAssetPath, erbImageAssetPath, done)
     })
     it('should have a correct text_for', function (done) {
@@ -68,11 +69,11 @@ describe('Transpilation', function () {
     let handlebarsTranspiler
 
     beforeEach(function () {
-      handlebarsTranspiler = transpiler('handlebars')
+      handlebarsTranspiler = transpiler('handlebars', nunjucksAssetVersion)
     })
 
     it('should have a correct asset_path', function (done) {
-      const handlebarsAssetPath = `<link href="{{{ asset_path }}}stylesheets/govuk-template.css" media="screen" rel="stylesheet" />`
+      const handlebarsAssetPath = `<link href="{{{ asset_path }}}stylesheets/govuk-template.css?1.0.0" media="screen" rel="stylesheet" />`
       transpilationTest(handlebarsTranspiler, nunjucksAssetPath, handlebarsAssetPath, done)
     })
     it('should have a correct text_for', function (done) {
@@ -89,11 +90,11 @@ describe('Transpilation', function () {
     let djangoTranspiler
 
     beforeEach(function () {
-      djangoTranspiler = transpiler('django')
+      djangoTranspiler = transpiler('django', nunjucksAssetVersion)
     })
 
     it('should have a correct asset_path', function (done) {
-      const djangoAssetPath = `<link href="{% static 'stylesheets/govuk-template.css' %}" media="screen" rel="stylesheet" />`
+      const djangoAssetPath = `<link href="{% static 'stylesheets/govuk-template.css?1.0.0' %}" media="screen" rel="stylesheet" />`
       transpilationTest(djangoTranspiler, nunjucksAssetPath, djangoAssetPath, done)
     })
     it('should have a correct text_for', function (done) {

--- a/test/specs/transpiler_spec.js
+++ b/test/specs/transpiler_spec.js
@@ -50,11 +50,11 @@ describe('Transpilation', function () {
       transpilationTest(erbTranspiler, nunjucksImageAssetPath, erbImageAssetPath, done)
     })
     it('should have a correct text_for', function (done) {
-      const erbTextFor = `<a href="#content" class="skiplink"><%= content_for?(:skip_link_message) ? yield(:skip_link_message) : 'Skip to main content' %></a>`
+      const erbTextFor = `<a href="#content" class="skiplink"><%= content_for?(:skip_link_message) ? yield(:skip_link_message) : 'Skip to main content'.html_safe %></a>`
       transpilationTest(erbTranspiler, nunjucksTextFor, erbTextFor, done)
     })
     it('should have a correct block_for', function (done) {
-      const erbBlockFor = `<%= content_for?(:top_of_page) ? yield(:top_of_page) : '' %>`
+      const erbBlockFor = `<%= content_for?(:top_of_page) ? yield(:top_of_page) : ''.html_safe %>`
       transpilationTest(erbTranspiler, nunjucksBlockFor, erbBlockFor, done)
     })
     it('should have a correct block_for for the special case content block', function (done) {

--- a/test/specs/transpiler_spec.js
+++ b/test/specs/transpiler_spec.js
@@ -35,9 +35,19 @@ describe('Transpilation', function () {
       erbTranspiler = transpiler('erb')
     })
 
-    it('should have a correct asset_path', function (done) {
-      const erbAssetPath = `<link href="<%= asset_path 'stylesheets/govuk-template.css' %>" media="screen" rel="stylesheet" />`
-      transpilationTest(erbTranspiler, nunjucksAssetPath, erbAssetPath, done)
+    it('should have a correct asset_path for stylesheets', function (done) {
+      const erbStylesheetsAssetPath = `<link href="<%= asset_path 'govuk-template.css' %>" media="screen" rel="stylesheet" />`
+      transpilationTest(erbTranspiler, nunjucksAssetPath, erbStylesheetsAssetPath, done)
+    })
+    it('should have a correct asset_path for javascript', function (done) {
+      const nunjucksJavascriptAssetPath = `<script src="{{ asset_path + 'javascript/govuk-template.js' }}"></script>`
+      const erbJavascriptAssetPath = `<script src="<%= asset_path 'govuk-template.js' %>"></script>`
+      transpilationTest(erbTranspiler, nunjucksJavascriptAssetPath, erbJavascriptAssetPath, done)
+    })
+    it('should have a correct asset_path for images', function (done) {
+      const nunjucksImageAssetPath = `<img src="{{ asset_path + 'images/govuk-template.png' }}" alt="" />`
+      const erbImageAssetPath = `<img src="<%= asset_path 'govuk-template.png' %>" alt="" />`
+      transpilationTest(erbTranspiler, nunjucksImageAssetPath, erbImageAssetPath, done)
     })
     it('should have a correct text_for', function (done) {
       const erbTextFor = `<a href="#content" class="skiplink"><%= content_for?(:skip_link_message) ? yield(:skip_link_message) : 'Skip to main content' %></a>`


### PR DESCRIPTION
This adds an first stab at an unbranded template. It’ll benefit from modularising individual components, but that can happen later. It’ll also need work on the styling - this is purely the HTML.

As part of the PR I’ve also fixed the broken ERB transpilation and changed the templates to dynamically append a version number to the assets for cache busting.
