### PR TITLE
Add asset versions to the Nunjucks templates

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,11 +39,7 @@ let transpileRunner = templateLanguage => {
     .pipe(gulp.dest(paths.dist))
 }
 gulp.task('transpile', ['transpile:nunjucks', 'transpile:erb', 'transpile:handlebars', 'transpile:django'])
-gulp.task('transpile:nunjucks', () => {
-  return gulp.src(paths.templates + '*.html')
-    .pipe(rename({extname: '.html.nunjucks'}))
-    .pipe(gulp.dest(paths.dist))
-})
+gulp.task('transpile:nunjucks', transpileRunner.bind(null, 'nunjucks'))
 gulp.task('transpile:erb', transpileRunner.bind(null, 'erb'))
 gulp.task('transpile:handlebars', transpileRunner.bind(null, 'handlebars'))
 gulp.task('transpile:django', transpileRunner.bind(null, 'django'))

--- a/lib/transpilation/django_transpiler.js
+++ b/lib/transpilation/django_transpiler.js
@@ -2,10 +2,10 @@
 
 // Django templates for Python
 
-const asset_path = (asset, version) => `{% static '${asset}?${version}' %}`
-const block_for = (key, defaultContent = '') => `{% block ${key} %}${defaultContent}{% endblock %}`
-const text_for = (key, defaultContent = '') => `{{ ${key}|default:'${defaultContent}' }}`
+const assetPath = (asset, version) => `{% static '${asset}?${version}' %}`
+const blockFor = (key, defaultContent = '') => `{% block ${key} %}${defaultContent}{% endblock %}`
+const textFor = (key, defaultContent = '') => `{{ ${key}|default:'${defaultContent}' }}`
 
-module.exports.asset_path = asset_path
-module.exports.block_for = block_for
-module.exports.text_for = text_for
+module.exports.assetPath = assetPath
+module.exports.blockFor = blockFor
+module.exports.textFor = textFor

--- a/lib/transpilation/erb_transpiler.js
+++ b/lib/transpilation/erb_transpiler.js
@@ -2,11 +2,11 @@
 
 // ERB templates for Ruby
 
-const asset_path = (asset, version) => {
+const assetPath = (asset, version) => {
   asset = asset.replace(/^stylesheets\/|javascript\/|images\//, '')
   return `<%= asset_path '${asset}?${version}' %>`
 }
-const block_for = (key, defaultContent = '') => {
+const blockFor = (key, defaultContent = '') => {
   if (key === 'content') {
     // ERB needs a default yield
     return '<%= content_for?(:content) ? yield(:content) : yield %>'
@@ -14,8 +14,8 @@ const block_for = (key, defaultContent = '') => {
     return `<%= content_for?(:${key}) ? yield(:${key}) : '${defaultContent}'.html_safe %>`
   }
 }
-const text_for = (key, defaultContent = '') => block_for(key, defaultContent)
+const textFor = (key, defaultContent = '') => blockFor(key, defaultContent)
 
-module.exports.asset_path = asset_path
-module.exports.block_for = block_for
-module.exports.text_for = text_for
+module.exports.assetPath = assetPath
+module.exports.blockFor = blockFor
+module.exports.textFor = textFor

--- a/lib/transpilation/handlebars_transpiler.js
+++ b/lib/transpilation/handlebars_transpiler.js
@@ -3,10 +3,10 @@
 // Handlebars templates
 // http://handlebarsjs.com/
 
-const asset_path = (asset, version) => `{{{ asset_path }}}${asset}?${version}`
-const block_for = (key, defaultContent = '') => `{{#if ${key}}}{{{ ${key} }}}{{else}}${defaultContent}{{/if}}`
-const text_for = (key, defaultContent = '') => block_for(key, defaultContent)
+const assetPath = (asset, version) => `{{{ asset_path }}}${asset}?${version}`
+const blockFor = (key, defaultContent = '') => `{{#if ${key}}}{{{ ${key} }}}{{else}}${defaultContent}{{/if}}`
+const textFor = (key, defaultContent = '') => blockFor(key, defaultContent)
 
-module.exports.asset_path = asset_path
-module.exports.block_for = block_for
-module.exports.text_for = text_for
+module.exports.assetPath = assetPath
+module.exports.blockFor = blockFor
+module.exports.textFor = textFor

--- a/lib/transpilation/nunjucks_transpiler.js
+++ b/lib/transpilation/nunjucks_transpiler.js
@@ -3,6 +3,6 @@
 // Nunjucks templates
 // The original template is already in Nunjucks, but needs version markers added
 
-const asset_path = (asset, version) => `{{ asset_path }}${asset}?${version}`
+const assetPath = (asset, version) => `{{ asset_path }}${asset}?${version}`
 
-module.exports.asset_path = asset_path
+module.exports.assetPath = assetPath

--- a/lib/transpilation/nunjucks_transpiler.js
+++ b/lib/transpilation/nunjucks_transpiler.js
@@ -1,0 +1,8 @@
+'use strict'
+
+// Nunjucks templates
+// The original template is already in Nunjucks, but needs version markers added
+
+const asset_path = (asset, version) => `{{ asset_path }}${asset}?${version}`
+
+module.exports.asset_path = asset_path

--- a/lib/transpilation/transpiler.js
+++ b/lib/transpilation/transpiler.js
@@ -17,18 +17,18 @@ const transpile = (target, assetVersion) => {
       let replacement
       if (arguments[1] !== undefined) {
         // asset_path pattern
-        replacement = targetTranspiler.asset_path !== undefined ?
-          targetTranspiler.asset_path(arguments[1], assetVersion) :
+        replacement = targetTranspiler.assetPath !== undefined ?
+          targetTranspiler.assetPath(arguments[1], assetVersion) :
           match
       } else if (arguments[2] !== undefined) {
         // text_for pattern
-        replacement = targetTranspiler.text_for !== undefined ?
-          targetTranspiler.text_for(arguments[2], arguments[3]) :
+        replacement = targetTranspiler.textFor !== undefined ?
+          targetTranspiler.textFor(arguments[2], arguments[3]) :
           match
       } else if (arguments[4] !== undefined) {
         // block_for pattern
-        replacement = targetTranspiler.block_for !== undefined ?
-          targetTranspiler.block_for(arguments[4], arguments[5]) :
+        replacement = targetTranspiler.blockFor !== undefined ?
+          targetTranspiler.blockFor(arguments[4], arguments[5]) :
           match
       }
       return replacement

--- a/lib/transpilation/transpiler.js
+++ b/lib/transpilation/transpiler.js
@@ -17,13 +17,19 @@ const transpile = (target, assetVersion) => {
       let replacement
       if (arguments[1] !== undefined) {
         // asset_path pattern
-        replacement = targetTranspiler.asset_path(arguments[1], assetVersion)
+        replacement = targetTranspiler.asset_path !== undefined ?
+          targetTranspiler.asset_path(arguments[1], assetVersion) :
+          match
       } else if (arguments[2] !== undefined) {
         // text_for pattern
-        replacement = targetTranspiler.text_for(arguments[2], arguments[3])
+        replacement = targetTranspiler.text_for !== undefined ?
+          targetTranspiler.text_for(arguments[2], arguments[3]) :
+          match
       } else if (arguments[4] !== undefined) {
         // block_for pattern
-        replacement = targetTranspiler.block_for(arguments[4], arguments[5])
+        replacement = targetTranspiler.block_for !== undefined ?
+          targetTranspiler.block_for(arguments[4], arguments[5]) :
+          match
       }
       return replacement
     })

--- a/test/specs/transpiler_spec.js
+++ b/test/specs/transpiler_spec.js
@@ -29,6 +29,25 @@ describe('Transpilation', function () {
     })
   })
 
+  describe('into Nunjucks', function () {
+    let nunjucksTranspiler
+
+    beforeEach(function () {
+      nunjucksTranspiler = transpiler('nunjucks', nunjucksAssetVersion)
+    })
+
+    it('should have a correct asset_path', function (done) {
+      const transpiledAssetPath = `<link href="{{ asset_path }}stylesheets/govuk-template.css?1.0.0" media="screen" rel="stylesheet" />`
+      transpilationTest(nunjucksTranspiler, nunjucksAssetPath, transpiledAssetPath, done)
+    })
+    it('should have a correct text_for', function (done) {
+      transpilationTest(nunjucksTranspiler, nunjucksTextFor, nunjucksTextFor, done)
+    })
+    it('should have a correct block_for', function (done) {
+      transpilationTest(nunjucksTranspiler, nunjucksBlockFor, nunjucksBlockFor, done)
+    })
+  })
+
   describe('into ERB', function () {
     let erbTranspiler
 


### PR DESCRIPTION
Originally we were simply copying the templates, but we need to process to add the cache-busting version numbers.
