### PR TITLE
Build a package for npm

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -9,6 +9,7 @@ const paths = {
   distJs: 'dist/assets/js/',
   distTemplates: 'dist/templates/',
   distPkg: 'dist/pkg/',
+  distPkgNpm: 'dist/pkg/npm/',
   npm: 'node_modules/',
   test: 'test/',
   testSpecs: 'test/specs/'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -157,11 +157,21 @@ gulp.task('build', cb => {
   runSequence('clean', ['build:templates', 'build:styles', 'build:scripts'], cb)
 })
 
-// Package the contents of dist
-gulp.task('package', ['package:tgz'])
-gulp.task('package:tgz', () => {
-  gulp.src(paths.dist + '*')
-    .pipe(tar(packageJson.name + '-' + packageJson.version + '.tar'))
-    .pipe(gzip())
-    .pipe(gulp.dest(paths.distPkg))
+// Build packages
+gulp.task('package', cb => {
+  runSequence('clean', 'build', [
+    'package:npm'
+  ], cb)
+})
+
+// Build NPM package
+gulp.task('package:npm', () => {
+  gulp.src([
+    'package.json',
+    paths.dist + '**/*'
+  ])
+  .pipe(gulp.dest(paths.distPkgNpm))
+  .pipe(tar(packageJson.name + '-' + packageJson.version + '.tar'))
+  .pipe(gzip())
+  .pipe(gulp.dest(paths.distPkgNpm))
 })


### PR DESCRIPTION
This PR adds a task to copy the contents of /dist into a npm folder and zips its contents.

Where I’m using paths.distPkgNpm, it would be better to pass in the
package type, so this can be reused for other packages.

Also, I’m not sure it’s useful to keep the contents of dist/pkg/npm
once the zip has been produced so it might be worth adding a clean step
to remove assets and templates from this folder.
