### PR TITLE
Add a 'help' task to list available tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,7 @@ const packageName = packageJson.name + '-' + packageJson.version
 const paths = require('./config/paths.json')
 
 // Run 'gulp help' to list available tasks
-gulp.task('help', taskListing)
+gulp.task('help', taskListing.withFilters(null, 'help'))
 
 // Task for cleaning the distribution
 gulp.task('clean', () => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ const gulp = require('gulp')
 const del = require('del')
 const rename = require('gulp-rename')
 const runSequence = require('run-sequence')
+const taskListing = require('gulp-task-listing')
 
 // Templates
 const transpiler = require('./lib/transpilation/transpiler.js')
@@ -37,6 +38,9 @@ const packageName = packageJson.name + '-' + packageJson.version
 
 // Configuration
 const paths = require('./config/paths.json')
+
+// Run 'gulp help' to list available tasks
+gulp.task('help', taskListing)
 
 // Task for cleaning the distribution
 gulp.task('clean', () => {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gulp-sass-lint": "^1.2.0",
     "gulp-standard": "^8.0.2",
     "gulp-tar": "^1.9.0",
+    "gulp-task-listing": "^1.0.1",
     "gulp-uglify": "^2.0.0",
     "gulp-util": "^3.0.7",
     "jasmine-spec-reporter": "^2.7.0",


### PR DESCRIPTION
[gulp-task-listing](https://www.npmjs.com/package/gulp-task-listing) looks like a useful thing to add.

This PR adds a task ‘gulp help’ to list available tasks.

Screenshot:

![screen shot 2016-10-28 at 14 18 29](https://cloud.githubusercontent.com/assets/417754/19807749/7df2f3c0-9d19-11e6-871d-b8d3b3733ad3.png)
