### PR TITLE
Add an expectation of node version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "alphagov/govuk_frontend_alpha",
   "author": "Government Digital Service developers (https://gds.blog.gov.uk/)",
   "license": "MIT",
+  "engines" : { "node" : ">= 6.0" },
   "bugs": {
     "url": "https://github.com/alphagov/govuk_frontend_alpha/issues"
   },


### PR DESCRIPTION
I don't think this is automatically enforced, or automatically switched too (like `rvm` or such), but it gives a hint that older versions of node won't work with this package.

I picked 6 as something reasonably modern, within the last 6 months, but it's a bit arbitrary. I know i had problems with a version <= 5 though.

Note; This won't apply to the build `npm` package, as the engine value isn't carried over, and the version is needed for a devDependency only.