### PR TITLE
Update sass-lint to 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "phantomjs-prebuilt": "^2.1.13",
     "rollup-stream": "^1.14.0",
     "run-sequence": "^1.2.2",
-    "sass-lint": "git://github.com/sasstools/sass-lint.git#feature/disable-linters",
+    "sass-lint": "1.10.0",
     "through2": "^2.0.1",
     "uglify-save-license": "^0.4.1",
     "vinyl-buffer": "^1.0.0",


### PR DESCRIPTION
This PR updates sass-lint to 1.10.0 to enable linters to be disabled within source files.

The documentation for these rules can be found here: https://github.com/sasstools/sass-lint/blob/master/docs/toggle-rules-in-src.md.
