### PR TITLE
Add the lint task to gulp test

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -125,7 +125,7 @@ gulp.task('build:scripts:copy', () => {
 // Task to run the tests
 // This runs preview first, to copy assets from dist/bundle to /public, then runs the tests
 gulp.task('test', cb => {
-  runSequence('preview', 'test:lib', 'test:toolkit', 'test:preview', cb)
+  runSequence('lint', 'preview', 'test:lib', 'test:toolkit', 'test:preview', cb)
 })
 
 gulp.task('test:lib', () => gulp.src(paths.testSpecs + 'transpiler_spec.js', {read: false})

--- a/test/specs/preview_spec.js
+++ b/test/specs/preview_spec.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const app = require('../../server.js')
 const server = app.listen()
 const request = require('supertest').agent(server)
@@ -36,10 +37,11 @@ describe('Copy assets to public and run the app...', function () {
         .expect('Content-Type', /text\/html/)
         .expect(200)
         .end(function (err, res) {
-          if (err)
+          if (err) {
             done(err)
-          else
+          } else {
             done()
+          }
         })
     })
   })


### PR DESCRIPTION
Add the lint task to `gulp test`.

This means that Travis will run `gulp test` for each PR, so all files in this repo will be linted. 

Fix the preview_spec.js file as the gulp lint task is currently failing on this file.