### PR TITLE
Add npm debug logs to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .DS_Store
 dist/
 public/
+npm-debug.log*


### PR DESCRIPTION
Tiny tweak, but i've almost accidentally added it a couple of times.