### PR TITLE
Split the existing gulpfile into seperate modules

### DIFF
--- a/config/paths.json
+++ b/config/paths.json
@@ -30,5 +30,6 @@
   "pkg": "dist/pkg/",
   "node_modules": "node_modules/",
   "test": "test/",
-  "testSpecs": "test/specs/"
+  "testSpecs": "test/specs/",
+  "lib": "lib/"
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,184 +1,36 @@
 'use strict'
 
+// Configuration
 const packageJson = require('./package.json')
-const fs = require('fs')
+const paths = require('./config/paths.json')
+exports.packageName = packageJson.name + '-' + packageJson.version
 
 // Gulp utility
 const gulp = require('gulp')
 const del = require('del')
-const rename = require('gulp-rename')
 const runSequence = require('run-sequence')
 const taskListing = require('gulp-task-listing')
 
-// Templates
-const transpiler = require('./lib/transpilation/transpiler.js')
+// Gulp sub-tasks
+require('./lib/tasks/build-templates.js')
+require('./lib/tasks/build-images.js')
+require('./lib/tasks/build-styles.js')
+require('./lib/tasks/build-scripts.js')
 
-// Styles
-const sass = require('gulp-sass')
-const sasslint = require('gulp-sass-lint')
-const nano = require('gulp-cssnano')
+require('./lib/tasks/package-npm.js')
+require('./lib/tasks/package-gem.js')
 
-// Javascript
-const standard = require('gulp-standard')
-const rollup = require('rollup-stream')
-const vinylSource = require('vinyl-source-stream')
-const vinylBuffer = require('vinyl-buffer')
-const uglify = require('gulp-uglify')
-const uglifySaveLicense = require('uglify-save-license')
+require('./lib/tasks/lint.js')
+require('./lib/tasks/test.js')
 
-// Testing
-const mocha = require('gulp-mocha')
-const jasmineBrowser = require('gulp-jasmine-browser')
-const SpecReporter = require('jasmine-spec-reporter')
-
-// Packaging
-const run = require('gulp-run')
-const packageName = packageJson.name + '-' + packageJson.version
-
-// Configuration
-const paths = require('./config/paths.json')
-
-// Development
-const nodemon = require('gulp-nodemon')
+require('./lib/tasks/preview.js')
+require('./lib/tasks/start-server.js')
 
 // Run 'gulp help' to list available tasks
 gulp.task('help', taskListing.withFilters(null, 'help'))
 
 // Task for cleaning the distribution
-gulp.task('clean', () => {
-  return del([paths.dist + '*', paths.public + '*'])
-})
-
-// Copy images
-gulp.task('build:images', () => {
-  return gulp.src(paths.assetsImg + '**/*')
-    .pipe(gulp.dest(paths.bundleImg))
-})
-
-// Task for transpiling the templates
-let transpileRunner = templateLanguage => {
-  return gulp.src(paths.templates + '*.html')
-    .pipe(transpiler(templateLanguage, packageJson.version))
-    .pipe(rename({extname: '.html.' + templateLanguage}))
-    .pipe(gulp.dest(paths.bundleTemplates))
-}
-gulp.task('build:templates', ['build:templates:nunjucks', 'build:templates:erb', 'build:templates:handlebars', 'build:templates:django'])
-gulp.task('build:templates:nunjucks', transpileRunner.bind(null, 'nunjucks'))
-gulp.task('build:templates:erb', transpileRunner.bind(null, 'erb'))
-gulp.task('build:templates:handlebars', transpileRunner.bind(null, 'handlebars'))
-gulp.task('build:templates:django', transpileRunner.bind(null, 'django'))
-
-// Compile Sass to CSS
-gulp.task('build:styles', cb => {
-  runSequence('lint:styles', ['build:styles:copy', 'build:styles:compile'], cb)
-})
-gulp.task('build:styles:compile', () => {
-  return gulp.src(paths.assetsScss + '**/*.scss')
-    .pipe(sass().on('error', sass.logError))
-    .pipe(gulp.dest(paths.bundleCss))
-    .pipe(rename({ suffix: '.min' }))
-    .pipe(nano())
-    .pipe(gulp.dest(paths.bundleCss))
-})
-gulp.task('build:styles:copy', () => {
-  return gulp.src(paths.assetsScss + '**/*.scss')
-    .pipe(gulp.dest(paths.bundleScss))
-})
-
-// Build single Javascript file from modules
-let scriptsBuilder = fileName => {
-  return rollup({
-    entry: paths.assetsJs + fileName + '.manifest.js',
-    context: 'window'
-  })
-    .pipe(vinylSource(fileName + '.js'))
-    .pipe(gulp.dest(paths.bundleJs))
-    .pipe(vinylBuffer())
-    .pipe(rename({ suffix: '.min' }))
-    .pipe(uglify({
-      preserveComments: uglifySaveLicense
-    }))
-    .pipe(gulp.dest(paths.bundleJs))
-}
-gulp.task('build:scripts', cb => {
-  runSequence('lint:scripts', [
-    'build:scripts:copy',
-    'build:scripts:elements',
-    'build:scripts:govuk-template',
-    'build:scripts:govuk-template-ie',
-    'build:scripts:toolkit'
-  ], cb)
-})
-gulp.task('build:scripts:elements', scriptsBuilder.bind(null, 'elements'))
-gulp.task('build:scripts:govuk-template', scriptsBuilder.bind(null, 'govuk-template'))
-gulp.task('build:scripts:govuk-template-ie', scriptsBuilder.bind(null, 'govuk-template-ie'))
-gulp.task('build:scripts:toolkit', scriptsBuilder.bind(null, 'toolkit'))
-gulp.task('build:scripts:copy', () => {
-  return gulp.src(paths.assetsJs + '**/*.js')
-    .pipe(gulp.dest(paths.bundleJs))
-})
-
-// Task to run the tests
-// This runs preview first, to copy assets from dist/bundle to /public, then runs the tests
-gulp.task('test', cb => {
-  runSequence('lint', 'preview', 'test:lib', 'test:toolkit', 'test:preview', cb)
-})
-
-gulp.task('test:lib', () => gulp.src(paths.testSpecs + 'transpiler_spec.js', {read: false})
-  .pipe(mocha({reporter: 'spec'}))
-)
-// Ideally these pre-existing toolkit tests will be rewritten at some point
-// to use mocha rather than requiring Jasmine as well.
-gulp.task('test:toolkit', () => gulp.src([
-  paths.node_modules + 'jquery/dist/jquery.js',
-  paths.assetsJs + 'toolkit/**/*.js',
-  paths.testSpecs + 'toolkit/unit/**/*.spec.js'
-])
-  .pipe(jasmineBrowser.specRunner({console: true}))
-  .pipe(jasmineBrowser.headless({reporter: new SpecReporter()}))
-)
-
-gulp.task('test:preview', () => gulp.src(paths.testSpecs + 'preview_spec.js', {read: false})
-  .pipe(mocha({reporter: 'spec'}))
-  .once('error', () => {
-    process.exit(1)
-  })
-  .once('end', () => {
-    process.exit()
-  })
-)
-
-// Linting
-gulp.task('lint', ['lint:styles', 'lint:scripts', 'lint:tests'])
-gulp.task('lint:styles', () => {
-  return gulp.src(paths.assetsScss + '**/*.scss')
-    .pipe(sasslint())
-    // if the .yml file is in /config, this fails :(
-    // .pipe(sasslint({
-    //   config: paths.config + '.sass-lint.yml'
-    // }))
-    .pipe(sasslint.format())
-    .pipe(sasslint.failOnError())
-})
-gulp.task('lint:scripts', () => {
-  return gulp.src([
-    '!' + paths.assetsJs + '**/vendor/**/*.js',
-    paths.assetsJs + '**/*.js'
-  ])
-    .pipe(standard())
-    .pipe(standard.reporter('default', {
-      breakOnError: true,
-      quiet: true
-    }))
-})
-gulp.task('lint:tests', () => {
-  return gulp.src(paths.test + '**/*.js')
-    .pipe(standard())
-    .pipe(standard.reporter('default', {
-      breakOnError: true,
-      quiet: true
-    }))
-})
+gulp.task('clean', () => del([paths.dist + '*', paths.public + '*']))
 
 // Build distribution
 // This runs the build task to build the assets from app to dist/bundle
@@ -186,78 +38,18 @@ gulp.task('build', cb => {
   runSequence('clean', ['build:templates', 'build:images', 'build:styles', 'build:scripts'], cb)
 })
 
+// Linting
+gulp.task('lint', ['lint:styles', 'lint:scripts', 'lint:tests'])
+
+// Task to run the tests
+// This runs preview first, to copy assets from dist/bundle to /public, then runs the tests
+gulp.task('test', cb => {
+  runSequence('lint', 'preview', 'test:lib', 'test:toolkit', 'test:preview', cb)
+})
+
 // Package the contents of dist
 gulp.task('package', cb => {
   runSequence('build', ['package:gem', 'package:npm'], cb)
-})
-
-gulp.task('package:gem', () => {
-  runSequence('package:gem:prepare', 'package:gem:build', 'package:gem:copy', 'package:gem:clean')
-})
-
-gulp.task('package:gem:prepare', () => {
-  gulp.src(paths.bundleCss + '**/*').pipe(gulp.dest(paths.gemCss))
-  gulp.src(paths.bundleImg + '**/*').pipe(gulp.dest(paths.gemImg))
-  gulp.src(paths.bundleScss + '**/*').pipe(gulp.dest(paths.gemScss))
-  gulp.src(paths.bundleJs + '**/*').pipe(gulp.dest(paths.gemJs))
-  gulp.src(paths.bundleTemplates + '**/*').pipe(gulp.dest(paths.gemTemplates))
-  return gulp.src(`lib/packaging/gem/${packageJson.name}.gemspec`).pipe(gulp.dest(paths.gem))
-})
-
-gulp.task('package:gem:build', () => run(`cd ${paths.gem} && gem build ${packageJson.name}.gemspec`).exec())
-gulp.task('package:gem:copy', () => gulp.src(`${paths.gem}${packageName}.gem`).pipe(gulp.dest(paths.pkg)))
-gulp.task('package:gem:clean', () => del(`${paths.gem}${packageName}.gem`))
-
-const buildNpmPackageJson = () => {
-  const npmPackageJson = {}
-  npmPackageJson['name'] = packageJson.name
-  npmPackageJson['version'] = packageJson.version
-  npmPackageJson['description'] = packageJson.description
-  npmPackageJson['repository'] = packageJson.repository
-  npmPackageJson['author'] = packageJson.author
-  npmPackageJson['license'] = packageJson.license
-  npmPackageJson['bugs'] = packageJson.bugs
-  npmPackageJson['homepage'] = packageJson.homepage
-  return JSON.stringify(npmPackageJson)
-}
-
-gulp.task('package:npm', () => {
-  runSequence('package:npm:prepare', 'package:npm:json', 'package:npm:build', 'package:npm:copy', 'package:npm:clean')
-})
-
-gulp.task('package:npm:prepare', () => {
-  gulp.src(paths.bundleCss + '**/*').pipe(gulp.dest(paths.npmCss))
-  gulp.src(paths.bundleImg + '**/*').pipe(gulp.dest(paths.npmImg))
-  gulp.src(paths.bundleScss + '**/*').pipe(gulp.dest(paths.npmScss))
-  gulp.src(paths.bundleJs + '**/*').pipe(gulp.dest(paths.npmJs))
-  gulp.src(paths.bundleTemplates + '**/*').pipe(gulp.dest(paths.npmTemplates))
-  return gulp.src('./package.json').pipe(gulp.dest(paths.npm))
-})
-
-gulp.task('package:npm:json', cb => fs.writeFile(paths.npm + 'package.json', buildNpmPackageJson(), cb))
-gulp.task('package:npm:build', () => run(`cd ${paths.npm} && npm pack`).exec())
-gulp.task('package:npm:copy', () => gulp.src(`${paths.npm}${packageName}.tgz`).pipe(gulp.dest(paths.pkg)))
-gulp.task('package:npm:clean', () => del(`${paths.npm}${packageName}.tgz`))
-
-// Copy files to /public
-// This runs the build task first, then copies the assets from dist/bundle to /public
-gulp.task('preview', cb => {
-  runSequence('build', ['preview:copy:styles', 'preview:copy:images', 'preview:copy:js'], cb)
-})
-
-gulp.task('preview:copy:styles', () => {
-  return gulp.src(paths.bundleCss + '*.css')
-    .pipe(gulp.dest(paths.publicCss))
-})
-
-gulp.task('preview:copy:images', () => {
-  return gulp.src(paths.bundleImg + '**/*')
-    .pipe(gulp.dest(paths.publicImg))
-})
-
-gulp.task('preview:copy:js', () => {
-  return gulp.src(paths.bundleJs + '**/*.js')
-    .pipe(gulp.dest(paths.publicJs))
 })
 
 // Start server
@@ -266,13 +58,8 @@ gulp.task('start', cb => {
   runSequence('preview', ['start:server'], cb)
 })
 
-gulp.task('start:server', function () {
-  nodemon({
-    script: 'server.js',
-    ext: 'js html',
-    env: { 'NODE_ENV': 'development' }
-  })
-    .on('restart', function () {
-      console.log('App restarted...')
-    })
+// Copy files to /public
+// This runs the build task first, then copies the assets from dist/bundle to /public
+gulp.task('preview', cb => {
+  runSequence('build', ['preview:copy:styles', 'preview:copy:images', 'preview:copy:js'], cb)
 })

--- a/lib/tasks/build-images.js
+++ b/lib/tasks/build-images.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const paths = require('../../config/paths.json')
+
+const gulp = require('gulp')
+
+// Copy images
+gulp.task('build:images', () => {
+  return gulp.src(paths.assetsImg + '**/*')
+    .pipe(gulp.dest(paths.bundleImg))
+})

--- a/lib/tasks/build-scripts.js
+++ b/lib/tasks/build-scripts.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const paths = require('../../config/paths.json')
+
+const gulp = require('gulp')
+const runSequence = require('run-sequence')
+const rename = require('gulp-rename')
+
+const rollup = require('rollup-stream')
+const vinylSource = require('vinyl-source-stream')
+const vinylBuffer = require('vinyl-buffer')
+const uglify = require('gulp-uglify')
+const uglifySaveLicense = require('uglify-save-license')
+
+let scriptsBuilder = fileName => {
+  return rollup({
+    entry: paths.assetsJs + fileName + '.manifest.js',
+    context: 'window'
+  })
+    .pipe(vinylSource(fileName + '.js'))
+    .pipe(gulp.dest(paths.bundleJs))
+    .pipe(vinylBuffer())
+    .pipe(rename({ suffix: '.min' }))
+    .pipe(uglify({
+      preserveComments: uglifySaveLicense
+    }))
+    .pipe(gulp.dest(paths.bundleJs))
+}
+
+// Build single Javascript file from modules
+gulp.task('build:scripts', cb => {
+  runSequence('lint:scripts', [
+    'build:scripts:copy',
+    'build:scripts:elements',
+    'build:scripts:govuk-template',
+    'build:scripts:govuk-template-ie',
+    'build:scripts:toolkit'
+  ], cb)
+})
+
+gulp.task('build:scripts:elements', scriptsBuilder.bind(null, 'elements'))
+gulp.task('build:scripts:govuk-template', scriptsBuilder.bind(null, 'govuk-template'))
+gulp.task('build:scripts:govuk-template-ie', scriptsBuilder.bind(null, 'govuk-template-ie'))
+gulp.task('build:scripts:toolkit', scriptsBuilder.bind(null, 'toolkit'))
+gulp.task('build:scripts:copy', () => {
+  return gulp.src(paths.assetsJs + '**/*.js')
+    .pipe(gulp.dest(paths.bundleJs))
+})

--- a/lib/tasks/build-styles.js
+++ b/lib/tasks/build-styles.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const paths = require('../../config/paths.json')
+
+const gulp = require('gulp')
+const runSequence = require('run-sequence')
+const rename = require('gulp-rename')
+
+const sass = require('gulp-sass')
+const nano = require('gulp-cssnano')
+
+// Compile Sass to CSS
+gulp.task('build:styles', cb => {
+  runSequence('lint:styles', [
+    'build:styles:copy',
+    'build:styles:compile'
+  ], cb)
+})
+
+gulp.task('build:styles:compile', () => {
+  return gulp.src(paths.assetsScss + '**/*.scss')
+    .pipe(sass().on('error', sass.logError))
+    .pipe(gulp.dest(paths.bundleCss))
+    .pipe(rename({ suffix: '.min' }))
+    .pipe(nano())
+    .pipe(gulp.dest(paths.bundleCss))
+})
+gulp.task('build:styles:copy', () => {
+  return gulp.src(paths.assetsScss + '**/*.scss')
+    .pipe(gulp.dest(paths.bundleScss))
+})

--- a/lib/tasks/build-templates.js
+++ b/lib/tasks/build-templates.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const packageJson = require('../../package.json')
+const paths = require('../../config/paths.json')
+
+const gulp = require('gulp')
+const rename = require('gulp-rename')
+
+const transpiler = require('../transpilation/transpiler.js')
+
+let transpileRunner = templateLanguage => {
+  return gulp.src(paths.templates + '*.html')
+    .pipe(transpiler(templateLanguage, packageJson.version))
+    .pipe(rename({extname: '.html.' + templateLanguage}))
+    .pipe(gulp.dest(paths.bundleTemplates))
+}
+
+// Task for transpiling the templates
+gulp.task('build:templates', [
+  'build:templates:nunjucks',
+  'build:templates:erb',
+  'build:templates:handlebars',
+  'build:templates:django'
+])
+
+gulp.task('build:templates:nunjucks', transpileRunner.bind(null, 'nunjucks'))
+gulp.task('build:templates:erb', transpileRunner.bind(null, 'erb'))
+gulp.task('build:templates:handlebars', transpileRunner.bind(null, 'handlebars'))
+gulp.task('build:templates:django', transpileRunner.bind(null, 'django'))

--- a/lib/tasks/lint.js
+++ b/lib/tasks/lint.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const paths = require('../../config/paths.json')
+
+const gulp = require('gulp')
+
+const sasslint = require('gulp-sass-lint')
+const standard = require('gulp-standard')
+
+gulp.task('lint:styles', () => {
+  return gulp.src(paths.assetsScss + '**/*.scss')
+    .pipe(sasslint())
+    // if the .yml file is in /config, this fails :(
+    // .pipe(sasslint({
+    //   config: paths.config + '.sass-lint.yml'
+    // }))
+    .pipe(sasslint.format())
+    .pipe(sasslint.failOnError())
+})
+gulp.task('lint:scripts', () => {
+  return gulp.src([
+    '!' + paths.assetsJs + '**/vendor/**/*.js',
+    paths.assetsJs + '**/*.js'
+  ])
+    .pipe(standard())
+    .pipe(standard.reporter('default', {
+      breakOnError: true,
+      quiet: true
+    }))
+})
+gulp.task('lint:tests', () => {
+  return gulp.src(paths.test + '**/*.js')
+    .pipe(standard())
+    .pipe(standard.reporter('default', {
+      breakOnError: true,
+      quiet: true
+    }))
+})

--- a/lib/tasks/package-gem.js
+++ b/lib/tasks/package-gem.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const packageJson = require('../../package.json')
+const paths = require('../../config/paths.json')
+const packageName = require('../../gulpfile.js').packageName
+
+const gulp = require('gulp')
+const runSequence = require('run-sequence')
+const run = require('gulp-run')
+const del = require('del')
+
+gulp.task('package:gem', cb => {
+  runSequence('package:gem:prepare', 'package:gem:build', 'package:gem:copy', 'package:gem:clean', cb)
+})
+
+gulp.task('package:gem:prepare', () => {
+  gulp.src(paths.bundleCss + '**/*').pipe(gulp.dest(paths.gemCss))
+  gulp.src(paths.bundleImg + '**/*').pipe(gulp.dest(paths.gemImg))
+  gulp.src(paths.bundleScss + '**/*').pipe(gulp.dest(paths.gemScss))
+  gulp.src(paths.bundleJs + '**/*').pipe(gulp.dest(paths.gemJs))
+  gulp.src(paths.bundleTemplates + '**/*').pipe(gulp.dest(paths.gemTemplates))
+  return gulp.src(`${paths.lib}packaging/gem/${packageJson.name}.gemspec`).pipe(gulp.dest(paths.gem))
+})
+
+gulp.task('package:gem:build', () => run(`cd ${paths.gem} && gem build ${packageJson.name}.gemspec`).exec())
+gulp.task('package:gem:copy', () => gulp.src(`${paths.gem}${packageName}.gem`).pipe(gulp.dest(paths.pkg)))
+gulp.task('package:gem:clean', () => del(`${paths.gem}${packageName}.gem`))

--- a/lib/tasks/package-npm.js
+++ b/lib/tasks/package-npm.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const packageJson = require('../../package.json')
+const paths = require('../../config/paths.json')
+const packageName = require('../../gulpfile.js').packageName
+
+const gulp = require('gulp')
+const runSequence = require('run-sequence')
+const run = require('gulp-run')
+const del = require('del')
+const fs = require('fs')
+
+const buildNpmPackageJson = () => {
+  const npmPackageJson = {}
+  npmPackageJson['name'] = packageJson.name
+  npmPackageJson['version'] = packageJson.version
+  npmPackageJson['description'] = packageJson.description
+  npmPackageJson['repository'] = packageJson.repository
+  npmPackageJson['author'] = packageJson.author
+  npmPackageJson['license'] = packageJson.license
+  npmPackageJson['bugs'] = packageJson.bugs
+  npmPackageJson['homepage'] = packageJson.homepage
+  return JSON.stringify(npmPackageJson)
+}
+
+gulp.task('package:npm', cb => {
+  runSequence('package:npm:prepare', 'package:npm:json', 'package:npm:build', 'package:npm:copy', 'package:npm:clean', cb)
+})
+
+gulp.task('package:npm:prepare', () => {
+  gulp.src(paths.bundleCss + '**/*').pipe(gulp.dest(paths.npmCss))
+  gulp.src(paths.bundleImg + '**/*').pipe(gulp.dest(paths.npmImg))
+  gulp.src(paths.bundleScss + '**/*').pipe(gulp.dest(paths.npmScss))
+  gulp.src(paths.bundleJs + '**/*').pipe(gulp.dest(paths.npmJs))
+  gulp.src(paths.bundleTemplates + '**/*').pipe(gulp.dest(paths.npmTemplates))
+  return gulp.src('./package.json').pipe(gulp.dest(paths.npm))
+})
+
+gulp.task('package:npm:json', cb => fs.writeFile(paths.npm + 'package.json', buildNpmPackageJson(), cb))
+gulp.task('package:npm:build', () => run(`cd ${paths.npm} && npm pack`).exec())
+gulp.task('package:npm:copy', () => gulp.src(`${paths.npm}${packageName}.tgz`).pipe(gulp.dest(paths.pkg)))
+gulp.task('package:npm:clean', () => del(`${paths.npm}${packageName}.tgz`))

--- a/lib/tasks/preview.js
+++ b/lib/tasks/preview.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const paths = require('../../config/paths.json')
+
+const gulp = require('gulp')
+
+gulp.task('preview:copy:styles', () => {
+  return gulp.src(paths.bundleCss + '*.css')
+    .pipe(gulp.dest(paths.publicCss))
+})
+
+gulp.task('preview:copy:images', () => {
+  return gulp.src(paths.bundleImg + '**/*')
+    .pipe(gulp.dest(paths.publicImg))
+})
+
+gulp.task('preview:copy:js', () => {
+  return gulp.src(paths.bundleJs + '**/*.js')
+    .pipe(gulp.dest(paths.publicJs))
+})

--- a/lib/tasks/start-server.js
+++ b/lib/tasks/start-server.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const gulp = require('gulp')
+const nodemon = require('gulp-nodemon')
+
+gulp.task('start:server', function () {
+  nodemon({
+    script: 'server.js',
+    ext: 'js html',
+    env: { 'NODE_ENV': 'development' }
+  })
+    .on('restart', function () {
+      console.log('App restarted...')
+    })
+})

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const paths = require('../../config/paths.json')
+
+const gulp = require('gulp')
+
+const mocha = require('gulp-mocha')
+const jasmineBrowser = require('gulp-jasmine-browser')
+const SpecReporter = require('jasmine-spec-reporter')
+
+gulp.task('test:lib', () => gulp.src(paths.testSpecs + 'transpiler_spec.js', {read: false})
+  .pipe(mocha({reporter: 'spec'}))
+)
+// Ideally these pre-existing toolkit tests will be rewritten at some point
+// to use mocha rather than requiring Jasmine as well.
+gulp.task('test:toolkit', () => gulp.src([
+  paths.node_modules + 'jquery/dist/jquery.js',
+  paths.assetsJs + 'toolkit/**/*.js',
+  paths.testSpecs + 'toolkit/unit/**/*.spec.js'
+])
+  .pipe(jasmineBrowser.specRunner({console: true}))
+  .pipe(jasmineBrowser.headless({reporter: new SpecReporter()}))
+)
+
+gulp.task('test:preview', () => gulp.src(paths.testSpecs + 'preview_spec.js', {read: false})
+  .pipe(mocha({reporter: 'spec'}))
+  .once('error', () => {
+    process.exit(1)
+  })
+  .once('end', () => {
+    process.exit()
+  })
+)


### PR DESCRIPTION
## What problem does the pull request solve?
Makes the existing gulpfile much easier to understand

## What does it do?
Modules now live in lib/gulp. Each module requires just the code it needs to work. Rather than use a requireDir solution the modules are individually required at the top of gulpfile.js. I’ve left the top level tasks in the main gulpfile for clarity of what’s available, but I could be argued into moving these into their respective modules if people feel that it’s a better idea. Single-command tasks I’ve left in the main gulpfile too - again, happy to change this if people want.

## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Put an `x` in all the boxes that apply
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.