### PR TITLE
Fix step icon SCSS

### DIFF
--- a/app/assets/scss/components/_icons.scss
+++ b/app/assets/scss/components/_icons.scss
@@ -65,12 +65,11 @@
   &--search {
     @include icon(icon-search, 30, 22);
   }
-}
 
-
-// GOV.UK step icons
-@for $i from 1 through 14 {
-  &--step-#{$i} {
-    @include icon(icon-step--#{$i}, 23, 23, icon-steps);
+  // GOV.UK step icons
+  @for $i from 1 through 14 {
+    &--step-#{$i} {
+      @include icon(icon-step--#{$i}, 23, 23, icon-steps);
+    }
   }
 }


### PR DESCRIPTION
This was failing in a ruby SASS environment, due to:

```Base-level rules cannot contain the parent-selector-referencing character '&'.```

Surprised this wasn't caught by the linter tbh, fixing it for now, but that
might need looking into later, otherwise we lose confidence in the linter
when building for other environments