### PR TITLE
Add a radio group component and error states

### DIFF
--- a/app/assets/scss/components/_button.scss
+++ b/app/assets/scss/components/_button.scss
@@ -158,14 +158,18 @@
   &:focus {
     outline: 3px solid $focus-colour;
   }
+}
 
-  &--disabled {
-    background: $button-colour;
+.gv-c-button--primary {
+  @include button ($button-colour);
+}
 
-    &:focus {
-      outline: none;
-    }
-  }
+.gv-c-button--disabled {
+  background: $button-colour;
+}
+
+.gv-c-button--disabled:focus {
+  outline: none;
 }
 
 

--- a/app/assets/scss/components/_form-custom.scss
+++ b/app/assets/scss/components/_form-custom.scss
@@ -54,10 +54,6 @@
       border-color: $black;
     }
 
-    &--last {
-      margin-bottom: 0;
-    }
-
   }
 
   // To stack horizontally, use .--inline, to sit block labels next to each other
@@ -75,4 +71,8 @@
   // &--checkbox {
   // }
 
+}
+
+.gv-c-form-custom:last-child {
+  margin-bottom: 0;
 }

--- a/app/assets/scss/components/_form-group.scss
+++ b/app/assets/scss/components/_form-group.scss
@@ -1,5 +1,4 @@
 .gv-c-form-group {
-
   // Set spacing here for now
   // TODO: this should be moved into a utility class
   margin-bottom: $gutter-half;
@@ -11,57 +10,86 @@
   @include box-sizing(border-box);
 
   @include clearfix;
-
-  // This is standard form label
-  &__label {
-    @include core-19;
-
-    display: block;
-    color: $text-colour;
-    padding-bottom: 2px;
-  }
-
-  // Sometimes bold labels are needed
-  &__label--bold {
-    @include bold-19;
-  }
-
-  // Form hints and example text are light grey and sit above a form control
-  // These might not be grey in the future, we need evidence to support this
-  &__hint {
-    @include core-19;
-    display: block;
-    color: $secondary-text-colour;
-    font-weight: normal;
-
-    margin-top: -2px;
-    padding-bottom: 2px;
-  }
-
-  // If a hint sits inside a label, we need to remove the spacing
-  // todo: This shoud be refactored but exists to have a class for how things are at present
-  &__hint--no-spacing {
-    margin-top: 0;
-    padding-bottom: 0;
-  }
-
-  // Used for inputs and textareas
-  &__control {
-    @include box-sizing(border-box);
-    @include core-19;
-    width: 100%;
-
-    padding: 4px;
-    background-color: $white;
-    border: 2px solid $grey-1;
-  }
-
-  // Used for native controls
-  &__native-control {
-    padding-right: 4px;
-  }
-
 }
+
+// Apply a left border to a form group
+// Use a state class, ensure this is chained to another element
+.gv-c-form-group.has-error {
+  border-left: 4px solid $error-colour;
+  padding-left: 10px;
+
+  @include media(tablet) {
+    border-left: 5px solid $error-colour;
+    padding-left: $gutter-half;
+  }
+}
+
+// This is standard form label
+.gv-c-form-group__label {
+  @include core-19;
+
+  display: block;
+  color: $text-colour;
+  padding-bottom: 2px;
+}
+
+// Sometimes bold labels are needed
+.gv-c-form-group__label--bold {
+  font-weight: 600;
+}
+
+// Form hints and example text are light grey and sit above a form control
+// These might not be grey in the future, we need evidence to support this
+.gv-c-form-group__hint {
+  @include core-19;
+  display: block;
+  color: $secondary-text-colour;
+  font-weight: normal;
+
+  margin-top: -2px;
+  padding-bottom: 2px;
+}
+
+// If a hint sits inside a label, we need to remove the spacing
+// todo: This shoud be refactored but exists to have a class for how things are at present
+.gv-c-form-group__hint--no-spacing {
+  margin-top: 0;
+  padding-bottom: 0;
+}
+
+// Used for inputs and textareas
+.gv-c-form-group__control {
+  @include box-sizing(border-box);
+  @include core-19;
+  width: 100%;
+
+  padding: 4px;
+  background-color: $white;
+  border: 2px solid $grey-1;
+}
+
+.gv-c-form-group__control.has-error {
+  border: 4px solid $error-colour;
+}
+
+// Used for native controls
+.gv-c-form-group__native-control {
+  padding-right: 4px;
+}
+
+// Error message styling
+.gv-c-form-group__error-message {
+  @include core-19;
+  color: $error-colour;
+  font-weight: bold;
+
+  display: block;
+  clear: both;
+
+  margin: 0;
+  padding: 4px 0 2px 0;
+}
+
 
 // Default radio buttons and checkboxes - not sure about these, own components, or .form-component--modifiers?
 // Using component names but leaving in this file for now

--- a/app/assets/scss/components/_form-group.scss
+++ b/app/assets/scss/components/_form-group.scss
@@ -14,7 +14,7 @@
 
 // Apply a left border to a form group
 // Use a state class, ensure this is chained to another element
-.gv-c-form-group.has-error {
+.gv-c-form-group--has-error {
   border-left: 4px solid $error-colour;
   padding-left: 10px;
 
@@ -68,7 +68,7 @@
   border: 2px solid $grey-1;
 }
 
-.gv-c-form-group__control.has-error {
+.gv-c-form-group__control--has-error {
   border: 4px solid $error-colour;
 }
 

--- a/app/assets/scss/components/_form-validation.scss
+++ b/app/assets/scss/components/_form-validation.scss
@@ -4,64 +4,8 @@
 // Form validation
 // ==========================================================================
 
-// Form inputs should have a red border
-.gv-c-form-group__control.error {
-  border: 4px solid $error-colour;
-}
-
-// Using the classname .error as it's shorter than .validation and easier to type!
-.error {
-
-  // Ensure the .error class is applied to .form-group, otherwide box-sizing(border-box) will need to be used
-  // @include box-sizing(border-box);
-  margin-right: 15px;
-
-  // Error messages should be red and bold
-  .error-message {
-    color: $error-colour;
-    font-weight: bold;
-  }
-
-  // Form inputs should have a red border
-  .form-control {
-    border: 4px solid $error-colour;
-  }
-
-}
-
-.error,
-.error-summary {
-
-  // Add a red border to the left of the field
-  border-left: 4px solid $error-colour;
-  padding-left: 10px;
-
-  @include media(tablet) {
-    border-left: 5px solid $error-colour;
-    padding-left: $gutter-half;
-  }
-}
-
-.error-message {
-  @include core-19;
-
-  display: block;
-  clear: both;
-
-  margin: 0;
-  padding: 2px 0;
-}
-
-// sass-lint:disable force-element-nesting
-.form-label .error-message,
-.form-label-bold .error-message {
-  padding-top: 4px;
-  padding-bottom: 0;
-}
-// sass-lint:enable force-element-nesting
-
 // Summary of multiple error messages
-.error-summary {
+.gv-error-summary {
 
   // Error summary has a border on all sides
   border: 4px solid $error-colour;

--- a/app/components/button.nunjucks
+++ b/app/components/button.nunjucks
@@ -1,4 +1,4 @@
-{% macro buttonComponent(isPrimary, text, type) %}
+{% macro buttonComponent(text, type, isPrimary) %}
   <button class="gv-c-button {% if isPrimary %}gv-c-button--primary{% endif %}" {% if type %}type="{{ type }}"{% endif %}>
     {{ text }}
   </button>

--- a/app/components/form-group.nunjucks
+++ b/app/components/form-group.nunjucks
@@ -1,14 +1,14 @@
 {% macro formGroupComponent(id, name, label, hint, error) %}
-  <div class="gv-c-form-group {% if error %}error{% endif %}">
+  <div class="gv-c-form-group {% if error %}has-error{% endif %}">
     <label class="gv-c-form-group__label" for="{{ id }}">
       {{ label }}
       {% if hint %}
         <span class="gv-c-form-group__hint">{{ hint }}</span>
       {% endif %}
       {% if error %}
-        <span class="error-message">{{ error }}</span>
+        <span class="gv-c-form-group__error-message">{{ error }}</span>
       {% endif %}
     </label>
-    <input class="gv-c-form-group__control {% if error %}error{% endif %}" id="{{ id }}" name="{{ name }}" value="" type="text">
+    <input class="gv-c-form-group__control {% if error %}has-error{% endif %}" id="{{ id }}" name="{{ name }}" value="" type="text">
   </div>
 {% endmacro %}

--- a/app/components/form-group.nunjucks
+++ b/app/components/form-group.nunjucks
@@ -1,5 +1,5 @@
 {% macro formGroupComponent(id, name, label, hint, error, isTextarea) %}
-  <div class="gv-c-form-group {% if error %}has-error{% endif %}">
+  <div class="gv-c-form-group {% if error %}gv-c-form-group--has-error{% endif %}">
     <label class="gv-c-form-group__label" for="{{ id }}">
       {{ label }}
       {% if hint %}
@@ -10,11 +10,11 @@
       {% endif %}
     </label>
     {% if isTextarea %}
-      <textarea class="gv-c-form-group__control {% if error %}has-error{% endif %}" id="{{ id }}" name="{{ name }}" cols="30" rows="5">
+      <textarea class="gv-c-form-group__control {% if error %}gv-c-form-group__control--has-error{% endif %}" id="{{ id }}" name="{{ name }}" cols="30" rows="5">
       </textarea>
     {% endif %}
     {% if not isTextarea %}
-      <input class="gv-c-form-group__control {% if error %}has-error{% endif %}" id="{{ id }}" name="{{ name }}" value="" type="text">
+      <input class="gv-c-form-group__control {% if error %}gv-c-form-group__control--has-error{% endif %}" id="{{ id }}" name="{{ name }}" value="" type="text">
     {% endif %}
   </div>
 {% endmacro %}

--- a/app/components/form-group.nunjucks
+++ b/app/components/form-group.nunjucks
@@ -1,4 +1,4 @@
-{% macro formGroupComponent(id, name, label, hint, error) %}
+{% macro formGroupComponent(id, name, label, hint, error, isTextarea) %}
   <div class="gv-c-form-group {% if error %}has-error{% endif %}">
     <label class="gv-c-form-group__label" for="{{ id }}">
       {{ label }}
@@ -9,6 +9,12 @@
         <span class="gv-c-form-group__error-message">{{ error }}</span>
       {% endif %}
     </label>
-    <input class="gv-c-form-group__control {% if error %}has-error{% endif %}" id="{{ id }}" name="{{ name }}" value="" type="text">
+    {% if isTextarea %}
+      <textarea class="gv-c-form-group__control {% if error %}has-error{% endif %}" id="{{ id }}" name="{{ name }}" cols="30" rows="5">
+      </textarea>
+    {% endif %}
+    {% if not isTextarea %}
+      <input class="gv-c-form-group__control {% if error %}has-error{% endif %}" id="{{ id }}" name="{{ name }}" value="" type="text">
+    {% endif %}
   </div>
 {% endmacro %}

--- a/app/components/form-radio-group.nunjucks
+++ b/app/components/form-radio-group.nunjucks
@@ -1,5 +1,5 @@
 {% macro formRadioGroupComponent(id, name, legend, hint, error, radioGroup) %}
-  <div class="gv-c-form-group {% if error %}has-error{% endif %}">
+  <div class="gv-c-form-group {% if error %}gv-c-form-group--has-error{% endif %}">
     <fieldset>
 
       <legend>

--- a/app/components/form-radio-group.nunjucks
+++ b/app/components/form-radio-group.nunjucks
@@ -1,0 +1,28 @@
+{% macro formRadioGroupComponent(id, name, legend, hint, error, radioGroup) %}
+  <div class="gv-c-form-group {% if error %}has-error{% endif %}">
+    <fieldset>
+
+      <legend>
+        <span class="form-label">{{ legend }}</span>
+        {% if hint %}
+          <span class="gv-c-form-group__hint">{{ hint }}</span>
+        {% endif %}
+        {% if error %}
+          <span class="gv-c-form-group__error-message">{{ error }}</span>
+        {% endif %}
+      </legend>
+
+      {% for name, radio in radioGroup %}
+        <label class="gv-c-form-custom" for="{{radio.id}}">
+          <input class="gv-c-form-custom__control"
+                 id="{{radio.id}}"
+                 type="radio"
+                 name="{{ id }}"
+                 value="{{ radio.value }}" {% if value == radio.value %} checked{% endif %}>
+          {{ radio.label }}
+        </label>
+      {% endfor %}
+
+    </fieldset>
+  </div>
+{% endmacro %}

--- a/app/data/form-group.js
+++ b/app/data/form-group.js
@@ -5,6 +5,7 @@ module.exports = {
     name: '',
     label: '',
     hint: '',
-    error: ''
+    error: '',
+    isTextarea: ''
   }
 }

--- a/app/data/form-radio-group.js
+++ b/app/data/form-radio-group.js
@@ -1,0 +1,27 @@
+module.exports = {
+  title: 'Form radio group',
+  context: {
+    id: 'contact',
+    name: 'contact-group',
+    legend: 'How do you want to be contacted?',
+    hint: 'Hint text in here',
+    error: 'Error text in here',
+    radioGroup: {
+      radio1: {
+        id: 'example-contact-by-email',
+        value: 'contact-by-email',
+        label: 'Email'
+      },
+      radio2: {
+        id: 'example-contact-by-phone',
+        value: 'contact-by-phone',
+        label: 'Text'
+      },
+      radio3: {
+        id: 'example-contact-by-text',
+        value: 'contact-by-text',
+        label: 'Phone'
+      }
+    }
+  }
+}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -76,7 +76,31 @@
                                                   radioGroup=formRadioGroupData.context.radioGroup
                                                   ) }}
     -->
-
+    <div class="gv-u-mb-10">
+      {{ formRadioGroup.formRadioGroupComponent("contact",
+                                                "contact-group",
+                                                "How do you want to be contacted?",
+                                                "Hint text in here",
+                                                "",
+                                                {
+                                                  radio1: {
+                                                    id: 'example-contact-by-email-1',
+                                                    value: 'contact-by-email',
+                                                    label: 'Email'
+                                                  },
+                                                  radio2: {
+                                                    id: 'example-contact-by-phone-2',
+                                                    value: 'contact-by-phone',
+                                                    label: 'Text'
+                                                  },
+                                                  radio3: {
+                                                    id: 'example-contact-by-text-3',
+                                                    value: 'contact-by-text',
+                                                    label: 'Phone'
+                                                  }
+                                                }
+                                                ) }}
+    </div>
     <div class="gv-u-mb-10">
       {{ formRadioGroup.formRadioGroupComponent("contact",
                                                 "contact-group",

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -20,12 +20,12 @@
     <div class="gv-u-mb-10">
     <!-- To refer to, for the examples below -->
     <!--
-      {{ formGroup.formGroupComponent(id=formGroupData.context.id,
-                                    name=formGroupData.context.name,
-                                    label=formGroupData.context.label,
-                                    hint=formGroupData.context.hint,
-                                    error=formGroupData.context.error,
-                                    isTextarea==formGroupData.context.isTextarea) }}
+      {{ formGroup.formGroupComponent(id=formRadioGroupData.context.id,
+                                    name=formRadioGroupData.context.name,
+                                    label=formRadioGroupData.context.label,
+                                    hint=formRadioGroupData.context.hint,
+                                    error=formRadioGroupData.context.error,
+                                    isTextarea==formRadioGroupData.context.isTextarea) }}
     -->
     </div>
 
@@ -66,25 +66,45 @@
                                     "Error message about National Insurance number goes here") }}
     </div>
 
-    <div class="gv-u-mb-10">
-    {{ formGroup.formGroupComponent("nino",
-                                    "nino",
-                                    "What is your National Insurance number",
-                                    "It'll be on your last payslip. For example, VO 12 34 56 D.",
-                                    "",
-                                    "true")
-                                    }}
-    </div>
+    {% import "../components/form-radio-group.nunjucks" as formRadioGroup %}
 
     <div class="gv-u-mb-10">
-    {{ formGroup.formGroupComponent("nino",
-                                    "nino",
-                                    "What is your National Insurance number",
-                                    "It'll be on your last payslip. For example, VO 12 34 56 D.",
-                                    "Error message about National Insurance number goes here",
-                                    "true")
-                                    }}
+    {{ formRadioGroup.formRadioGroupComponent(id=formRadioGroupData.context.id,
+                                  name=formRadioGroupData.context.name,
+                                  legend=formRadioGroupData.context.legend,
+                                  hint=formRadioGroupData.context.hint,
+                                  error=formRadioGroupData.context.error,
+                                  radioGroup=formRadioGroupData.context.radioGroup
+                                  ) }}
     </div>
+
+    <!-- Example of passing data to the above macro:
+    <div class="gv-u-mb-10">
+
+      {{ formRadioGroup.formRadioGroupComponent("contact",
+                                    "contact-group",
+                                    "How do you want to be contacted?",
+                                    "Hint text in here",
+                                    "Error text in here",
+                                    {
+                                      radio1: {
+                                        id: 'example-contact-by-email-1',
+                                        value: 'contact-by-email',
+                                        label: 'Email'
+                                      },
+                                      radio2: {
+                                        id: 'example-contact-by-phone-2',
+                                        value: 'contact-by-phone',
+                                        label: 'Text'
+                                      },
+                                      radio3: {
+                                        id: 'example-contact-by-text-3',
+                                        value: 'contact-by-text',
+                                        label: 'Phone'
+                                      }
+                                    }
+                                    ) }}
+    </div> -->
 
   </main>
 {% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -19,11 +19,14 @@
 
     <div class="govuk-u-mb-10">
     <!-- To refer to, for the examples below -->
-    <!-- {{ formGroup.formGroupComponent(id=formGroupData.context.id,
+    <!--
+      {{ formGroup.formGroupComponent(id=formGroupData.context.id,
                                     name=formGroupData.context.name,
                                     label=formGroupData.context.label,
                                     hint=formGroupData.context.hint,
-                                    error=formGroupData.context.error) }} -->
+                                    error=formGroupData.context.error,
+                                    isTextarea==formGroupData.context.isTextarea) }}
+    -->
     </div>
 
     <div class="govuk-u-mb-10">
@@ -61,6 +64,26 @@
                                     "What is your National Insurance number",
                                     "It'll be on your last payslip. For example, VO 12 34 56 D.",
                                     "Error message about National Insurance number goes here") }}
+    </div>
+
+    <div class="govuk-u-mb-10">
+    {{ formGroup.formGroupComponent("nino",
+                                    "nino",
+                                    "What is your National Insurance number",
+                                    "It'll be on your last payslip. For example, VO 12 34 56 D.",
+                                    "",
+                                    "true")
+                                    }}
+    </div>
+
+    <div class="govuk-u-mb-10">
+    {{ formGroup.formGroupComponent("nino",
+                                    "nino",
+                                    "What is your National Insurance number",
+                                    "It'll be on your last payslip. For example, VO 12 34 56 D.",
+                                    "Error message about National Insurance number goes here",
+                                    "true")
+                                    }}
     </div>
 
   </main>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -4,12 +4,12 @@
   <main class="gv-o-wrapper">
     {% import "../components/button.nunjucks" as button %}
 
-    <div class="govuk-u-mb-10">
+    <div class="gv-u-mb-10">
     {{ button.buttonComponent(text=buttonData.context.text,
                               type=buttonData.context.type) }}
     </div>
 
-    <div class="govuk-u-mb-10">
+    <div class="gv-u-mb-10">
     {{ button.buttonComponent(text=buttonPrimaryData.context.text,
                               type=buttonPrimaryData.context.type,
                               isPrimary=buttonPrimaryData.context.isPrimary) }}
@@ -17,7 +17,7 @@
 
     {% import "../components/form-group.nunjucks" as formGroup %}
 
-    <div class="govuk-u-mb-10">
+    <div class="gv-u-mb-10">
     <!-- To refer to, for the examples below -->
     <!--
       {{ formGroup.formGroupComponent(id=formGroupData.context.id,
@@ -29,20 +29,20 @@
     -->
     </div>
 
-    <div class="govuk-u-mb-10">
+    <div class="gv-u-mb-10">
     {{ formGroup.formGroupComponent("full-name",
                                     "full-name",
                                     "Full name") }}
     </div>
 
-    <div class="govuk-u-mb-10">
+    <div class="gv-u-mb-10">
     {{ formGroup.formGroupComponent("full-name",
                                     "full-name",
                                     "Full name",
                                     "As shown on your birth certificate or passport") }}
     </div>
 
-    <div class="govuk-u-mb-10">
+    <div class="gv-u-mb-10">
     {{ formGroup.formGroupComponent("full-name",
                                     "full-name",
                                     "Full name",
@@ -50,7 +50,7 @@
                                     "Error message about full name goes here") }}
     </div>
 
-    <div class="govuk-u-mb-10">
+    <div class="gv-u-mb-10">
     {{ formGroup.formGroupComponent("nino",
                                     "nino",
                                     "What is your National Insurance number",
@@ -58,7 +58,7 @@
                                     "") }}
     </div>
 
-    <div class="govuk-u-mb-10">
+    <div class="gv-u-mb-10">
     {{ formGroup.formGroupComponent("nino",
                                     "nino",
                                     "What is your National Insurance number",
@@ -66,7 +66,7 @@
                                     "Error message about National Insurance number goes here") }}
     </div>
 
-    <div class="govuk-u-mb-10">
+    <div class="gv-u-mb-10">
     {{ formGroup.formGroupComponent("nino",
                                     "nino",
                                     "What is your National Insurance number",
@@ -76,7 +76,7 @@
                                     }}
     </div>
 
-    <div class="govuk-u-mb-10">
+    <div class="gv-u-mb-10">
     {{ formGroup.formGroupComponent("nino",
                                     "nino",
                                     "What is your National Insurance number",

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -3,45 +3,46 @@
 {% block content %}
   <main class="gv-o-wrapper">
     {% import "../components/button.nunjucks" as button %}
-
-    <div class="gv-u-mb-10">
-    {{ button.buttonComponent(text=buttonData.context.text,
-                              type=buttonData.context.type) }}
-    </div>
-
-    <div class="gv-u-mb-10">
-    {{ button.buttonComponent(text=buttonPrimaryData.context.text,
+     <!-- To refer to, for the examples below -->
+     <!--
+     {{ button.buttonComponent(text=buttonPrimaryData.context.text,
                               type=buttonPrimaryData.context.type,
                               isPrimary=buttonPrimaryData.context.isPrimary) }}
-    </div>
-
-    {% import "../components/form-group.nunjucks" as formGroup %}
+    -->
 
     <div class="gv-u-mb-10">
+    {{ button.buttonComponent("Button text",
+                              "") }}
+    </div>
+    <div class="gv-u-mb-10">
+    {{ button.buttonComponent("Primary button text",
+                              "submit",
+                              "isPrimary") }}
+    </div>
+
+
+    {% import "../components/form-group.nunjucks" as formGroup %}
     <!-- To refer to, for the examples below -->
     <!--
       {{ formGroup.formGroupComponent(id=formRadioGroupData.context.id,
-                                    name=formRadioGroupData.context.name,
-                                    label=formRadioGroupData.context.label,
-                                    hint=formRadioGroupData.context.hint,
-                                    error=formRadioGroupData.context.error,
-                                    isTextarea==formRadioGroupData.context.isTextarea) }}
+                                      name=formRadioGroupData.context.name,
+                                      label=formRadioGroupData.context.label,
+                                      hint=formRadioGroupData.context.hint,
+                                      error=formRadioGroupData.context.error,
+                                      isTextarea==formRadioGroupData.context.isTextarea) }}
     -->
-    </div>
 
     <div class="gv-u-mb-10">
     {{ formGroup.formGroupComponent("full-name",
                                     "full-name",
                                     "Full name") }}
     </div>
-
     <div class="gv-u-mb-10">
     {{ formGroup.formGroupComponent("full-name",
                                     "full-name",
                                     "Full name",
                                     "As shown on your birth certificate or passport") }}
     </div>
-
     <div class="gv-u-mb-10">
     {{ formGroup.formGroupComponent("full-name",
                                     "full-name",
@@ -49,7 +50,6 @@
                                     "As shown on your birth certificate or passport",
                                     "Error message about full name goes here") }}
     </div>
-
     <div class="gv-u-mb-10">
     {{ formGroup.formGroupComponent("nino",
                                     "nino",
@@ -57,7 +57,6 @@
                                     "It'll be on your last payslip. For example, VO 12 34 56 D.",
                                     "") }}
     </div>
-
     <div class="gv-u-mb-10">
     {{ formGroup.formGroupComponent("nino",
                                     "nino",
@@ -67,44 +66,42 @@
     </div>
 
     {% import "../components/form-radio-group.nunjucks" as formRadioGroup %}
+    <!-- To refer to, for the examples below -->
+    <!--
+        {{ formRadioGroup.formRadioGroupComponent(id=formRadioGroupData.context.id,
+                                                  name=formRadioGroupData.context.name,
+                                                  legend=formRadioGroupData.context.legend,
+                                                  hint=formRadioGroupData.context.hint,
+                                                  error=formRadioGroupData.context.error,
+                                                  radioGroup=formRadioGroupData.context.radioGroup
+                                                  ) }}
+    -->
 
     <div class="gv-u-mb-10">
-    {{ formRadioGroup.formRadioGroupComponent(id=formRadioGroupData.context.id,
-                                  name=formRadioGroupData.context.name,
-                                  legend=formRadioGroupData.context.legend,
-                                  hint=formRadioGroupData.context.hint,
-                                  error=formRadioGroupData.context.error,
-                                  radioGroup=formRadioGroupData.context.radioGroup
-                                  ) }}
-    </div>
-
-    <!-- Example of passing data to the above macro:
-    <div class="gv-u-mb-10">
-
       {{ formRadioGroup.formRadioGroupComponent("contact",
-                                    "contact-group",
-                                    "How do you want to be contacted?",
-                                    "Hint text in here",
-                                    "Error text in here",
-                                    {
-                                      radio1: {
-                                        id: 'example-contact-by-email-1',
-                                        value: 'contact-by-email',
-                                        label: 'Email'
-                                      },
-                                      radio2: {
-                                        id: 'example-contact-by-phone-2',
-                                        value: 'contact-by-phone',
-                                        label: 'Text'
-                                      },
-                                      radio3: {
-                                        id: 'example-contact-by-text-3',
-                                        value: 'contact-by-text',
-                                        label: 'Phone'
-                                      }
-                                    }
-                                    ) }}
-    </div> -->
+                                                "contact-group",
+                                                "How do you want to be contacted?",
+                                                "Hint text in here",
+                                                "Error text in here",
+                                                {
+                                                  radio1: {
+                                                    id: 'example-contact-by-email-1',
+                                                    value: 'contact-by-email',
+                                                    label: 'Email'
+                                                  },
+                                                  radio2: {
+                                                    id: 'example-contact-by-phone-2',
+                                                    value: 'contact-by-phone',
+                                                    label: 'Text'
+                                                  },
+                                                  radio3: {
+                                                    id: 'example-contact-by-text-3',
+                                                    value: 'contact-by-text',
+                                                    label: 'Phone'
+                                                  }
+                                                }
+                                                ) }}
+    </div>
 
   </main>
 {% endblock %}

--- a/server.js
+++ b/server.js
@@ -36,7 +36,8 @@ app.get('/', function (req, res) {
   let buttonData = require('./app/data/button.js')
   let buttonPrimaryData = require('./app/data/button-primary.js')
   // let formGroupData = require('./app/data/form-group.js')
-  res.render('index', { buttonData: buttonData, buttonPrimaryData: buttonPrimaryData })
+  let formRadioGroupData = require('./app/data/form-radio-group.js')
+  res.render('index', { buttonData: buttonData, buttonPrimaryData: buttonPrimaryData, formRadioGroupData: formRadioGroupData })
 })
 
 // Log when app is running

--- a/server.js
+++ b/server.js
@@ -35,9 +35,9 @@ app.use(function (req, res, next) {
 app.get('/', function (req, res) {
   let buttonData = require('./app/data/button.js')
   let buttonPrimaryData = require('./app/data/button-primary.js')
-  // let formGroupData = require('./app/data/form-group.js')
+  let formGroupData = require('./app/data/form-group.js')
   let formRadioGroupData = require('./app/data/form-radio-group.js')
-  res.render('index', { buttonData: buttonData, buttonPrimaryData: buttonPrimaryData, formRadioGroupData: formRadioGroupData })
+  res.render('index', { buttonData: buttonData, buttonPrimaryData: buttonPrimaryData, formGroupData: formGroupData, formRadioGroupData: formRadioGroupData })
 })
 
 // Log when app is running


### PR DESCRIPTION
This PR continues the inital work creating components as Nunjucks macros.

The error message styling uses BEM modifiers for error classes, so `.error` becomes either `.blockname--has-error` or `.blockname__elementname--has-error`.

Arguments passed to the button component are reordered, so the `isPrimary` flag is defined last.

Amends the form-group component to add a `isTextarea` flag, so form group component will default to use an input element, but if `isTextarea` is set, it will show a `<textarea>` element instead of `<input type="text">`.

Adds a radio group component and its error states.

Shows both ways to pass data to all components, the first is via a commonjs module, required and passed as an oject to the index template by server.js with the data we expect (so this can be used for tests). These examples are commented out above the second way to pass data.

The second is by entering data directly into the macro in the index page.