### PR TITLE
Add browser-sync and set up watch tasks

### DIFF
--- a/config/paths.json
+++ b/config/paths.json
@@ -30,7 +30,7 @@
   "publicCss": "public/stylesheets/",
   "publicJs": "public/javascripts/",
   "pkg": "dist/pkg/",
-  "node_modules": "node_modules/",
+  "nodeModules": "node_modules/",
   "test": "test/",
   "testSpecs": "test/specs/",
   "lib": "lib/"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ exports.packageName = packageJson.name + '-' + packageJson.version
 
 // Gulp utility
 const gulp = require('gulp')
+const browserSync = require('browser-sync')
 const del = require('del')
 const runSequence = require('run-sequence')
 const taskListing = require('gulp-task-listing')
@@ -24,6 +25,8 @@ require('./lib/tasks/lint.js')
 require('./lib/tasks/test.js')
 
 require('./lib/tasks/preview.js')
+require('./lib/tasks/browser-sync.js')
+require('./lib/tasks/watch.js')
 require('./lib/tasks/start-server.js')
 
 // Run 'gulp help' to list available tasks
@@ -52,14 +55,8 @@ gulp.task('package', cb => {
   runSequence('build', ['package:gem', 'package:npm'], cb)
 })
 
-// Start server
-// This runs the preview task first then starts the server
-gulp.task('start', cb => {
-  runSequence('preview', ['start:server'], cb)
-})
-
-// Copy files to /public
-// This runs the build task first, then copies the assets from dist/bundle to /public
+// Preview
+// This runs the build task first, watches and starts the server
 gulp.task('preview', cb => {
-  runSequence('build', ['preview:copy:styles', 'preview:copy:images', 'preview:copy:js'], cb)
+  runSequence('build', ['browser-sync', 'watch', 'start:server'], cb)
 })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,9 +45,9 @@ gulp.task('build', cb => {
 gulp.task('lint', ['lint:styles', 'lint:scripts', 'lint:tests'])
 
 // Task to run the tests
-// This runs preview first, to copy assets from dist/bundle to /public, then runs the tests
+// This runs build before testing the preview task, to copy assets to dist/bundle and /public
 gulp.task('test', cb => {
-  runSequence('lint', 'preview', 'test:lib', 'test:toolkit', 'test:preview', cb)
+  runSequence('lint', 'test:lib', 'test:toolkit', 'build', 'test:preview', cb)
 })
 
 // Package the contents of dist

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,5 +58,5 @@ gulp.task('package', cb => {
 // Preview
 // This runs the build task first, watches and starts the server
 gulp.task('preview', cb => {
-  runSequence('build', ['browser-sync', 'watch', 'start:server'], cb)
+  runSequence('build', 'start:server', ['browser-sync', 'watch'], cb)
 })

--- a/lib/tasks/browser-sync.js
+++ b/lib/tasks/browser-sync.js
@@ -5,8 +5,12 @@ const browserSync = require('browser-sync')
 
 gulp.task('browser-sync', done => {
   return browserSync.init({
+    // Set the app to run on port 2950
+    // as browser sync is running on port 3000
     proxy: 'localhost:' + (3000 - 50),
+    // Browsersync includes a user-interface that is accessed via a separate port.
     port: 3000,
+    // Disable UI completely
     ui: false,
     files: ['public/**/*.*', 'app/components/**/*.*', 'app/views/**/*.*'],
     ghostmode: false,

--- a/lib/tasks/browser-sync.js
+++ b/lib/tasks/browser-sync.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const gulp = require('gulp')
+const browserSync = require('browser-sync')
+
+gulp.task('browser-sync', done => {
+  return browserSync.init({
+    proxy: 'localhost:' + (3000 - 50),
+    port: 3000,
+    ui: false,
+    files: ['public/**/*.*', 'app/components/**/*.*', 'app/views/**/*.*'],
+    ghostmode: false,
+    open: false,
+    notify: false,
+    logLevel: 'error'
+  })
+})

--- a/lib/tasks/build-images.js
+++ b/lib/tasks/build-images.js
@@ -8,4 +8,5 @@ const gulp = require('gulp')
 gulp.task('build:images', () => {
   return gulp.src(paths.assetsImg + '**/*')
     .pipe(gulp.dest(paths.bundleImg))
+    .pipe(gulp.dest(paths.publicImg))
 })

--- a/lib/tasks/build-scripts.js
+++ b/lib/tasks/build-scripts.js
@@ -19,6 +19,7 @@ let scriptsBuilder = fileName => {
   })
     .pipe(vinylSource(fileName + '.js'))
     .pipe(gulp.dest(paths.bundleJs))
+    .pipe(gulp.dest(paths.publicJs))
     .pipe(vinylBuffer())
     .pipe(rename({ suffix: '.min' }))
     .pipe(uglify({

--- a/lib/tasks/build-styles.js
+++ b/lib/tasks/build-styles.js
@@ -21,6 +21,7 @@ gulp.task('build:styles:compile', () => {
   return gulp.src(paths.assetsScss + '**/*.scss')
     .pipe(sass().on('error', sass.logError))
     .pipe(gulp.dest(paths.bundleCss))
+    .pipe(gulp.dest(paths.publicCss))
     .pipe(rename({ suffix: '.min' }))
     .pipe(nano())
     .pipe(gulp.dest(paths.bundleCss))

--- a/lib/tasks/start-server.js
+++ b/lib/tasks/start-server.js
@@ -1,12 +1,19 @@
 'use strict'
 
+const paths = require('../../config/paths.json')
+
 const gulp = require('gulp')
 const nodemon = require('gulp-nodemon')
 
 gulp.task('start:server', function () {
   nodemon({
     script: 'server.js',
-    ext: 'js json html',
+    ext: 'js, json, html, nunjucks',
+    ignore: [
+      paths.public + '*',
+      paths.dist + '*',
+      paths.nodeModules + '*'
+    ],
     env: { 'NODE_ENV': 'development' }
   })
     .on('restart', function () {

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -14,7 +14,7 @@ gulp.task('test:lib', () => gulp.src(paths.testSpecs + 'transpiler_spec.js', {re
 // Ideally these pre-existing toolkit tests will be rewritten at some point
 // to use mocha rather than requiring Jasmine as well.
 gulp.task('test:toolkit', () => gulp.src([
-  paths.node_modules + 'jquery/dist/jquery.js',
+  paths.nodeModules + 'jquery/dist/jquery.js',
   paths.assetsJs + 'toolkit/**/*.js',
   paths.testSpecs + 'toolkit/unit/**/*.spec.js'
 ])

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -24,6 +24,7 @@ gulp.task('test:toolkit', () => gulp.src([
 
 gulp.task('test:preview', () => gulp.src(paths.testSpecs + 'preview_spec.js', {read: false})
   .pipe(mocha({reporter: 'spec'}))
+  // https://github.com/sindresorhus/gulp-mocha#test-suite-not-exiting
   .once('error', () => {
     process.exit(1)
   })

--- a/lib/tasks/watch.js
+++ b/lib/tasks/watch.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const paths = require('../../config/paths.json')
+const gulp = require('gulp')
+
+gulp.task('watch', ['watch:styles', 'watch:scripts', 'watch:images'])
+
+gulp.task('watch:styles', function () {
+  return gulp.watch(paths.assetsScss + '**/*.scss', ['build:styles'])
+})
+
+gulp.task('watch:scripts', function () {
+  return gulp.watch(paths.assetsJs + '**/*.js', ['build:scripts'])
+})
+
+gulp.task('watch:images', function () {
+  return gulp.watch(paths.assetsImg + '**/*', ['build:images'])
+})

--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
   "repository": "alphagov/govuk_frontend_alpha",
   "author": "Government Digital Service developers (https://gds.blog.gov.uk/)",
   "license": "MIT",
-  "engines" : { "node" : ">= 6.0" },
+  "engines": {
+    "node": ">= 6.0"
+  },
   "bugs": {
     "url": "https://github.com/alphagov/govuk_frontend_alpha/issues"
   },
   "homepage": "https://github.com/alphagov/govuk_frontend_alpha#readme",
   "devDependencies": {
+    "browser-sync": "^2.18.1",
     "chai": "^3.5.0",
     "del": "^2.2.2",
     "event-stream": "^3.3.4",

--- a/server.js
+++ b/server.js
@@ -40,7 +40,7 @@ app.get('/', function (req, res) {
 })
 
 // Log when app is running
-app.listen(3000, function () {
+app.listen(3000 - 50, function () {
   console.log('GOV.UK Frontend Alpha\n')
   console.log('Listening on port 3000   url: http://localhost:3000')
 })

--- a/server.js
+++ b/server.js
@@ -40,6 +40,10 @@ app.get('/', function (req, res) {
 })
 
 // Log when app is running
+
+// Set the app to run on port 2950
+// as browser sync is running on port 3000
+
 app.listen(3000 - 50, function () {
   console.log('GOV.UK Frontend Alpha\n')
   console.log('Listening on port 3000   url: http://localhost:3000')


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->
This PR adds [browser-sync](https://www.browsersync.io/), so that any changes made to assets in `app/assets` can be previewed without needing to restart the application.

#### What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->
At present, if you make a change to one of the scss files - you must restart the app, to re-run the preview task, which then runs the build task and copies the assets to /public.

#### What does it do?
<!--- Describe your changes -->
This PR removes the copy step in the preview task, instead assets are copied to /public as part of the build step and the build step is re-run by the watch task when an asset is modified or added.

#### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
You can test this by running:

`gulp preview`

Then changing a file in app/assets/, the build task will run and the browser will update to show the change.

#### Screenshots (if appropriate):

#### What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

