### PR TITLE
Add build:components to the build task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,7 @@ gulp.task('clean', () => del([paths.dist + '*', paths.public + '*']))
 // Build distribution
 // This runs the build task to build the assets from app to dist/bundle
 gulp.task('build', cb => {
-  runSequence('clean', ['build:templates', 'build:images', 'build:styles', 'build:scripts'], cb)
+  runSequence('clean', ['build:templates', 'build:components', 'build:images', 'build:styles', 'build:scripts'], cb)
 })
 
 // Linting


### PR DESCRIPTION
This was missed from #72.

Add this task to the `build` task, to ensure components are copied to `dist/` ready for packaging.