### PR TITLE
Transpile components, supports ERB partials and a Rails component helper

### DIFF
--- a/app/components/button/button.config.json
+++ b/app/components/button/button.config.json
@@ -10,5 +10,6 @@
       "isPrimary": true,
       "text": "Primary button text"
     }
-  }]
+  }],
+  "arguments": ["text", "type", "isPrimary"]
 }

--- a/app/components/form-group/form-group.config.json
+++ b/app/components/form-group/form-group.config.json
@@ -32,5 +32,6 @@
     "context": {
       "isTextarea": "true"
     }
-  }]
+  }],
+  "arguments": ["id", "name", "label", "hint", "error", "isTextarea"]
 }

--- a/app/components/form-radio-group/form-radio-group.config.json
+++ b/app/components/form-radio-group/form-radio-group.config.json
@@ -39,5 +39,6 @@
       "hint": "Hint text in here",
       "error": "Error text in here"
     }
-  }]
+  }],
+  "arguments": ["id", "name", "legend", "hint", "error", "radioGroup"]
 }

--- a/config/paths.json
+++ b/config/paths.json
@@ -23,6 +23,7 @@
   "gemScss": "dist/gem/app/assets/stylesheets/",
   "gemJs": "dist/gem/app/assets/javascripts/",
   "gemTemplates": "dist/gem/app/views/layouts/",
+  "gemComponents": "dist/gem/app/views/components/",
   "npm": "dist/npm/",
   "npmCss": "dist/npm/assets/stylesheets/",
   "npmImg": "dist/npm/assets/images/",

--- a/lib/packaging/gem/lib/govuk_frontend_alpha.rb
+++ b/lib/packaging/gem/lib/govuk_frontend_alpha.rb
@@ -23,4 +23,10 @@ module GovukFrontendAlpha
       )
     end
   end
+
+  module ApplicationHelper
+    def govuk_component(name, props)
+      render partial: "components/#{name}", locals: props
+    end
+  end
 end

--- a/lib/tasks/build-components.js
+++ b/lib/tasks/build-components.js
@@ -21,7 +21,9 @@ let transpileRunner = templateLanguage => {
 
 // Task for transpiling the templates
 gulp.task('build:components', [
-  'build:components:nunjucks'
+  'build:components:nunjucks',
+  'build:components:erb'
 ])
 
 gulp.task('build:components:nunjucks', transpileRunner.bind(null, 'nunjucks'))
+gulp.task('build:components:erb', transpileRunner.bind(null, 'erb'))

--- a/lib/tasks/build-components.js
+++ b/lib/tasks/build-components.js
@@ -1,14 +1,27 @@
 'use strict'
 
 const paths = require('../../config/paths.json')
-const gulp = require('gulp')
+const packageJson = require('../../package.json')
 
-// Task for building the components
+const gulp = require('gulp')
+const rename = require('gulp-rename')
+
+const transpiler = require('../transpilation/transpiler.js')
+
+let transpileRunner = templateLanguage => {
+  return gulp.src(paths.appComponents + '*/*.nunj')
+    // `*/* vs `**/*` avoids including _preview.nunj in /components, which isn't a components
+    .pipe(transpiler.transpileComponent(templateLanguage, packageJson.version))
+    // no .html prefix like build:template, components have different naming convention
+    // @FIXME: standardise the naming convention in source
+    // `dirname` drops the extra level of dir, `button/button.ext` => `button.ext`
+    .pipe(rename({dirname: '', extname: '.' + templateLanguage}))
+    .pipe(gulp.dest(paths.bundleComponents))
+}
+
+// Task for transpiling the templates
 gulp.task('build:components', [
   'build:components:nunjucks'
 ])
 
-gulp.task('build:components:nunjucks', () => {
-  return gulp.src(paths.components + '**/*.html.nunjucks')
-  .pipe(gulp.dest(paths.bundleComponents))
-})
+gulp.task('build:components:nunjucks', transpileRunner.bind(null, 'nunjucks'))

--- a/lib/tasks/build-templates.js
+++ b/lib/tasks/build-templates.js
@@ -10,7 +10,7 @@ const transpiler = require('../transpilation/transpiler.js')
 
 let transpileRunner = templateLanguage => {
   return gulp.src(paths.templates + '*.html')
-    .pipe(transpiler(templateLanguage, packageJson.version))
+    .pipe(transpiler.transpileTemplate(templateLanguage, packageJson.version))
     .pipe(rename({extname: '.html.' + templateLanguage}))
     .pipe(gulp.dest(paths.bundleTemplates))
 }

--- a/lib/tasks/package-gem.js
+++ b/lib/tasks/package-gem.js
@@ -5,6 +5,7 @@ const paths = require('../../config/paths.json')
 const packageName = require('../../gulpfile.js').packageName
 
 const gulp = require('gulp')
+const rename = require('gulp-rename')
 const runSequence = require('run-sequence')
 const run = require('gulp-run')
 const del = require('del')
@@ -19,6 +20,12 @@ gulp.task('package:gem:prepare', () => {
   gulp.src(paths.bundleScss + '**/*').pipe(gulp.dest(paths.gemScss))
   gulp.src(paths.bundleJs + '**/*').pipe(gulp.dest(paths.gemJs))
   gulp.src(paths.bundleTemplates + '**/*').pipe(gulp.dest(paths.gemTemplates))
+
+  // Partials require a _ prefix
+  gulp.src(paths.bundleComponents + '**/*')
+    .pipe(rename({prefix: '_'}))
+    .pipe(gulp.dest(paths.gemComponents))
+
   gulp.src(`lib/packaging/gem/${packageJson.name}.gemspec`).pipe(gulp.dest(paths.gem))
   gulp.src('lib/packaging/gem/lib/govuk_frontend_alpha.rb').pipe(gulp.dest(paths.gemLib))
   return gulp.src('package.json').pipe(gulp.dest(paths.gemConfig))

--- a/lib/transpilation/erb_transpiler.js
+++ b/lib/transpilation/erb_transpiler.js
@@ -16,6 +16,15 @@ const blockFor = (key, defaultContent = '') => {
 }
 const textFor = (key, defaultContent = '') => blockFor(key, defaultContent)
 
+const componentArgs = (fileContents, name, args) => {
+  const defaults = args.map((arg) => `<% ${arg} = ${arg} or nil %>`)
+  return [
+    defaults.join('\n'),
+    fileContents
+  ].join('\n')
+}
+
 module.exports.assetPath = assetPath
 module.exports.blockFor = blockFor
 module.exports.textFor = textFor
+module.exports.componentArgs = componentArgs

--- a/lib/transpilation/nunjucks_transpiler.js
+++ b/lib/transpilation/nunjucks_transpiler.js
@@ -1,8 +1,22 @@
 'use strict'
 
+const changeCase = require('change-case')
+
 // Nunjucks templates
 // The original template is already in Nunjucks, but needs version markers added
 
 const assetPath = (asset, version) => `{{ asset_path }}${asset}?${version}`
 
+const componentArgs = (fileContents, name, args) => {
+  // Components are kebab-case, not a valid macro name, convention is camelCase
+  const func = `${changeCase.camelCase(name)}(${args.join(', ')})`
+  const parts = [
+    `{% macro ${func} %}`,
+    fileContents,
+    '{% endmacro %}'
+  ]
+  return parts.join('\n')
+}
+
 module.exports.assetPath = assetPath
+module.exports.componentArgs = componentArgs

--- a/lib/transpilation/transpiler.js
+++ b/lib/transpilation/transpiler.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const through = require('through2')
+const metaTemplate = require('meta-template')
 
 const assetPathPattern = /\{\{ asset_path \+ '(.*?)' \}\}/
 const textForPattern = /\{\{ (.*?)\|default\('(.*?)'\) \}\}/
@@ -44,6 +45,12 @@ const transpileComponent = (target) => {
   return through.obj((file, encoding, callback) => {
     if (file.isNull()) return callback(null, file)
 
+    // Meta template conversion
+    const node = metaTemplate.parse.buffer(new Buffer(file.contents))
+    const formatter = metaTemplate.format.get(target)
+    file.contents = new Buffer(formatter(node))
+
+    // Argument wrapping
     const name = file.path.split('/').pop().split('.')[0]
 
     // @TODO: Fix avoid sync file reads to get component config

--- a/lib/transpilation/transpiler.js
+++ b/lib/transpilation/transpiler.js
@@ -8,7 +8,7 @@ const blockForPattern = /\{% block (.*?) %\}(.*?)\{% endblock %\}/
 
 const transpilationPattern = new RegExp([assetPathPattern.source, textForPattern.source, blockForPattern.source].join('|'), 'g')
 
-const transpile = (target, assetVersion) => {
+const transpileTemplate = (target, assetVersion) => {
   return through.obj((file, encoding, callback) => {
     if (file.isNull()) return callback(null, file)
     const targetTranspiler = require(`./${target}_transpiler.js`)
@@ -40,4 +40,26 @@ const transpile = (target, assetVersion) => {
   })
 }
 
-module.exports = transpile
+const transpileComponent = (target) => {
+  return through.obj((file, encoding, callback) => {
+    if (file.isNull()) return callback(null, file)
+
+    const name = file.path.split('/').pop().split('.')[0]
+
+    // @TODO: Fix avoid sync file reads to get component config
+    var fs = require('fs');
+    var config = JSON.parse(fs.readFileSync(`./app/components/${name}/${name}.config.json`, 'utf8'));
+
+    const args = config.arguments || []
+    const targetTranspiler = require(`./${target}_transpiler.js`)
+
+    if (targetTranspiler.componentArgs) {
+      file.contents = new Buffer(targetTranspiler.componentArgs(file.contents, name, args))
+    }
+
+    callback(null, file)
+  })
+}
+
+module.exports.transpileTemplate = transpileTemplate
+module.exports.transpileComponent = transpileComponent

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gulp-util": "^3.0.7",
     "jasmine-spec-reporter": "^2.7.0",
     "jquery": "^3.1.1",
+    "meta-template": "https://github.com/dsingleton/meta-template/tarball/add-erb-support",
     "nunjucks": "^2.5.2",
     "phantomjs-prebuilt": "^2.1.13",
     "rollup-stream": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
       "$",
       "_gaq"
     ]
+  },
+  "dependencies": {
+    "change-case": "^3.0.0"
   }
 }

--- a/test/specs/transpiler_spec.js
+++ b/test/specs/transpiler_spec.js
@@ -19,7 +19,7 @@ const nunjucksBlockFor = `{% block top_of_page %}{% endblock %}`
 describe('Transpilation', function () {
   it('should return a Buffer', function (done) {
     let inputFile = new File({contents: new Buffer('test')})
-    let testTranspiler = transpiler('erb', nunjucksAssetVersion)
+    let testTranspiler = transpiler.transpileTemplate('erb', nunjucksAssetVersion)
     testTranspiler.write(inputFile)
     testTranspiler.once('data', function (file) {
       expect(file.isBuffer()).to.equal(true)
@@ -31,7 +31,7 @@ describe('Transpilation', function () {
     let nunjucksTranspiler
 
     beforeEach(function () {
-      nunjucksTranspiler = transpiler('nunjucks', nunjucksAssetVersion)
+      nunjucksTranspiler = transpiler.transpileTemplate('nunjucks', nunjucksAssetVersion)
     })
 
     it('should have a correct asset_path', function (done) {
@@ -50,7 +50,7 @@ describe('Transpilation', function () {
     let erbTranspiler
 
     beforeEach(function () {
-      erbTranspiler = transpiler('erb', nunjucksAssetVersion)
+      erbTranspiler = transpiler.transpileTemplate('erb', nunjucksAssetVersion)
     })
 
     it('should have a correct asset_path for stylesheets', function (done) {
@@ -86,7 +86,7 @@ describe('Transpilation', function () {
     let handlebarsTranspiler
 
     beforeEach(function () {
-      handlebarsTranspiler = transpiler('handlebars', nunjucksAssetVersion)
+      handlebarsTranspiler = transpiler.transpileTemplate('handlebars', nunjucksAssetVersion)
     })
 
     it('should have a correct asset_path', function (done) {
@@ -107,7 +107,7 @@ describe('Transpilation', function () {
     let djangoTranspiler
 
     beforeEach(function () {
-      djangoTranspiler = transpiler('django', nunjucksAssetVersion)
+      djangoTranspiler = transpiler.transpileTemplate('django', nunjucksAssetVersion)
     })
 
     it('should have a correct asset_path', function (done) {


### PR DESCRIPTION
The detail is in the individual commit messages. Overview is adding transpilation for components, this includes re-applying the `macro` defs in nunjucks. I've moved the argument info into the component config, as a single source of truth, and thats used to build different outputs.

Rails consumer example here: https://github.com/alphagov/govuk-frontend-alpha-rails/pull/1

Things i'm not keen on, but didn't want to fix in this PR:
- The dynamic requires, building paths with strings. I think we could do something with a components lib/module that hides the async JSON parsing, and exposes an array of available components, with a way to lookup an individual component too.
- Meta template running on GH branch - i need to chase the 3rd party PR, and see if they'd be interested in publishing to npm