### PR TITLE
[Discussion] [Do-Not-Merge] Handlebars components

### DIFF
--- a/lib/tasks/build-components.js
+++ b/lib/tasks/build-components.js
@@ -22,8 +22,10 @@ let transpileRunner = templateLanguage => {
 // Task for transpiling the templates
 gulp.task('build:components', [
   'build:components:nunjucks',
-  'build:components:erb'
+  'build:components:erb',
+  'build:components:handlebars'
 ])
 
 gulp.task('build:components:nunjucks', transpileRunner.bind(null, 'nunjucks'))
 gulp.task('build:components:erb', transpileRunner.bind(null, 'erb'))
+gulp.task('build:components:handlebars', transpileRunner.bind(null, 'handlebars'))


### PR DESCRIPTION
The build step works, in that it calls `meta-template`, but that fails to convert some template features in to handlebars as there isn't an equivalent feature there. This is the only example thats failing, but it's not an uncommon pattern:

```
{% if value == radio.value %} checked{% endif %}
```

Handlebars doesn't support comparisons in conditionals in the core language (it can be added with plugins, but that may be difficult to distribute).

*Discussion:*

- What is our minimum feature set for a template format? How is that enforced?
- How is that communicated to developers working on components?
- Is `handlebars` just not in our supported template list, and apps using it need to copy HTML, rather than versioned templates?

@gemmaleigh, @mcgoooo, @robinwhittleton 