### PR TITLE
Add testing around components

### DIFF
--- a/app/components/button/button.nunj
+++ b/app/components/button/button.nunj
@@ -1,3 +1,3 @@
 <button class="gv-c-button {% if isPrimary %}gv-c-button--primary{% endif %}">
-  {% if text %} {{ text }} {% endif %}
+  {% if text %}{{ text }}{% endif %}
 </button>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,7 @@ gulp.task('lint', ['lint:styles', 'lint:scripts', 'lint:tests'])
 
 // Task to run the tests
 gulp.task('test', cb => {
-  runSequence('lint', 'test:lib', 'test:toolkit', 'fractal:test', cb)
+  runSequence('lint', 'test:lib', 'test:components', 'test:toolkit', 'fractal:test', cb)
 })
 
 // Package the contents of dist

--- a/lib/components.js
+++ b/lib/components.js
@@ -1,0 +1,15 @@
+const glob = require('glob')
+const path = require('path')
+const paths = require('../config/paths')
+
+let configPattern = '/*/*.config.js'
+let components = {}
+
+glob.sync(path.join(paths.appComponents, configPattern)).forEach(file => {
+  // Parent path might change, so split on first part of file name
+  let name = path.basename(file).split('.')[0]
+  components[name] = require(path.relative(__dirname, file))
+})
+
+module.exports.all = components
+module.exports.get = name => components[name]

--- a/lib/components.js
+++ b/lib/components.js
@@ -13,3 +13,4 @@ glob.sync(path.join(paths.appComponents, configPattern)).forEach(file => {
 
 module.exports.all = components
 module.exports.get = name => components[name]
+module.exports.templatePathFor = name => path.join(paths.appComponents, name, `${name}.nunj`)

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -11,6 +11,11 @@ const SpecReporter = require('jasmine-spec-reporter')
 gulp.task('test:lib', () => gulp.src(paths.testSpecs + 'transpiler_spec.js', {read: false})
   .pipe(mocha({reporter: 'spec'}))
 )
+
+gulp.task('test:components', () => gulp.src(paths.testSpecs + 'components' + '**/*', {read: false})
+  .pipe(mocha({reporter: 'spec'}))
+)
+
 // Ideally these pre-existing toolkit tests will be rewritten at some point
 // to use mocha rather than requiring Jasmine as well.
 gulp.task('test:toolkit', () => gulp.src([

--- a/lib/transpilation/transpiler.js
+++ b/lib/transpilation/transpiler.js
@@ -46,28 +46,30 @@ const transpileComponent = (target) => {
   return through.obj((file, encoding, callback) => {
     if (file.isNull()) return callback(null, file)
 
-    // Meta template conversion
-    const node = metaTemplate.parse.buffer(new Buffer(file.contents))
-    const formatter = metaTemplate.format.get(target)
-    file.contents = new Buffer(formatter(node))
-
-    // Argument wrapping
     const name = file.path.split('/').pop().split('.')[0]
-
-    // @TODO: Fix avoid sync file reads to get component config
-    var fs = require('fs')
-    var config = fs.readFileSync(`./app/components/${name}/${name}.config.js`, 'utf8')
-
-    const args = config.arguments || []
-    const targetTranspiler = require(`./${target}_transpiler.js`)
-
-    if (targetTranspiler.componentArgs) {
-      file.contents = new Buffer(targetTranspiler.componentArgs(file.contents, name, args))
-    }
+    file.contents = new Buffer(transpileComponentSync(target, name, file.contents.toString('utf8')))
 
     callback(null, file)
   })
 }
 
+const transpileComponentSync = (target, componentName, componentTemplate) => {
+  // Meta template conversion
+  const node = metaTemplate.parse.string(componentTemplate)
+  const formatter = metaTemplate.format.get(target)
+  let transpiledTemplate = formatter(node)
+
+  // Argument wrapping
+  const args = components.get(componentName).arguments || []
+  const targetTranspiler = require(`./${target}_transpiler.js`)
+
+  if (targetTranspiler.componentArgs) {
+    transpiledTemplate = targetTranspiler.componentArgs(transpiledTemplate, componentName, args)
+  }
+
+  return transpiledTemplate
+}
+
 module.exports.transpileTemplate = transpileTemplate
 module.exports.transpileComponent = transpileComponent
+module.exports.transpileComponentSync = transpileComponentSync

--- a/lib/transpilation/transpiler.js
+++ b/lib/transpilation/transpiler.js
@@ -2,6 +2,7 @@
 
 const through = require('through2')
 const metaTemplate = require('meta-template')
+const components = require('../components')
 
 const assetPathPattern = /\{\{ asset_path \+ '(.*?)' \}\}/
 const textForPattern = /\{\{ (.*?)\|default\('(.*?)'\) \}\}/

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gulp-task-listing": "^1.0.1",
     "gulp-uglify": "^2.0.0",
     "gulp-util": "^3.0.7",
+    "html": "^1.0.0",
     "jasmine-spec-reporter": "^2.7.0",
     "jquery": "^3.1.1",
     "meta-template": "https://github.com/dsingleton/meta-template/tarball/add-erb-support",

--- a/test/specs/components/button_spec.js
+++ b/test/specs/components/button_spec.js
@@ -1,0 +1,23 @@
+const expectComponent = require('./helper').expectComponent
+
+describe('Button component', function () {
+  it('should render', () => {
+    expectComponent(
+      'button',
+      { text: 'hello!' },
+      `<button class="gv-c-button ">
+        hello!
+      </button>`
+    )
+  })
+
+  it('should render primary', function () {
+    expectComponent(
+      'button',
+      { text: 'hello!', isPrimary: true },
+      `<button class="gv-c-button gv-c-button--primary">
+        hello!
+      </button>`
+    )
+  })
+})

--- a/test/specs/components/form_group_spec.js
+++ b/test/specs/components/form_group_spec.js
@@ -1,0 +1,20 @@
+const expectComponent = require('./helper').expectComponent
+
+describe('Form group component', function () {
+  it('should render', () => {
+    expectComponent(
+      'form-group',
+      {
+        'id': 'full-name',
+        'name': 'full-name',
+        'label': 'Full name'
+      },
+      `<div class="gv-c-form-group ">
+        <label class="gv-c-form-group__label" for="full-name">
+          Full name
+        </label>
+        <input class="gv-c-form-group__control " id="full-name" name="full-name" value="" type="text">
+      </div>`
+    )
+  })
+})

--- a/test/specs/components/form_radio_group_spec.js
+++ b/test/specs/components/form_radio_group_spec.js
@@ -1,0 +1,47 @@
+const expectComponent = require('./helper').expectComponent
+
+describe('Form radio group component', function () {
+  it('should render', () => {
+    expectComponent(
+      'form-radio-group',
+      {
+        'id': 'contact',
+        'name': 'contact-group',
+        'legend': 'How do you want to be contacted?',
+        'radioGroup': [
+          {
+            'id': 'example-contact-by-email',
+            'value': 'contact-by-email',
+            'label': 'Email'
+          },
+          {
+            'id': 'example-contact-by-phone',
+            'value': 'contact-by-phone',
+            'label': 'Phone'
+          },
+          {
+            'id': 'example-contact-by-text',
+            'value': 'contact-by-text',
+            'label': 'Text'
+          }
+        ]
+      },
+      `<div class="gv-c-form-group ">
+        <fieldset>
+          <legend>
+            <span class="gv-c-form-group__label">How do you want to be contacted?</span>
+          </legend>
+          <label class="gv-c-form-custom" for="example-contact-by-email">
+            <input class="gv-c-form-custom__control" id="example-contact-by-email"
+            type="radio" name="contact" value="contact-by-email">Email</label>
+          <label class="gv-c-form-custom" for="example-contact-by-phone">
+            <input class="gv-c-form-custom__control" id="example-contact-by-phone"
+            type="radio" name="contact" value="contact-by-phone">Phone</label>
+          <label class="gv-c-form-custom" for="example-contact-by-text">
+            <input class="gv-c-form-custom__control" id="example-contact-by-text"
+            type="radio" name="contact" value="contact-by-text">Text</label>
+        </fieldset>
+      </div>`
+    )
+  })
+})

--- a/test/specs/components/helper.js
+++ b/test/specs/components/helper.js
@@ -1,11 +1,12 @@
 const expect = require('chai').expect
 const nunjucks = require('nunjucks')
 const html = require('html')
+const components = require('../../../lib/components')
 
 const normaliseHtml = string => html.prettyPrint(string, {indent_size: 2})
 
 const renderComponent = (name, input) => {
-  const componentPath = `app/components/${name}/${name}.nunj`
+  const componentPath = components.templatePathFor(name)
   return nunjucks.render(componentPath, input)
 }
 

--- a/test/specs/components/helper.js
+++ b/test/specs/components/helper.js
@@ -1,0 +1,21 @@
+const expect = require('chai').expect
+const nunjucks = require('nunjucks')
+const html = require('html')
+
+const normaliseHtml = string => html.prettyPrint(string, {indent_size: 2})
+
+const renderComponent = (name, input) => {
+  const componentPath = `app/components/${name}/${name}.nunj`
+  return nunjucks.render(componentPath, input)
+}
+
+const expectComponent = (name, input, expected) => {
+  // Normalise HTML whitespace, to make diffing simpler
+  expect(
+    normaliseHtml(renderComponent(name, input))
+  ).to.equal(
+    normaliseHtml(expected)
+  )
+}
+
+module.exports.expectComponent = expectComponent

--- a/test/specs/components/smoke_spec.js
+++ b/test/specs/components/smoke_spec.js
@@ -1,0 +1,22 @@
+const expect = require('chai').expect
+const nunjucks = require('nunjucks')
+const components = require('../../../lib/components')
+
+const expectComponentRenders = (name, input) => {
+  let componentPath = components.templatePathFor(name)
+  expect(() => {
+    nunjucks.render(componentPath, input)
+  }).to.not.throw()
+}
+
+describe('Components render examples without errors', function () {
+  Object.keys(components.all).map(name => {
+    it(`${name} component renders all variants without errors`, () => {
+      let component = components.get(name)
+      let variants = [component.context].concat(component.variants)
+      for (let variant of variants) {
+        expectComponentRenders(name, variant)
+      }
+    })
+  })
+})


### PR DESCRIPTION
The theme for this PR is increasing the amount of confidence we have when making changes to component templates.

1. This adds per-component specs. They're minimal implementations loosely inspired by [GOV.UK Publishing Components](https://github.com/alphagov/static/blob/master/test/govuk_component/title_test.rb). Ideally each component should have tests that cover all the possible paths through it's template logic, changes to a component template would have accompanying specs for new functionality.

2. Expose component configuration as a module, to reduce duplication and avoid dynamically loading config files. Makes writing code that uses component config easier, and more readable.

3. Use all of a components variants to run smoke tests, ensuring they don't generate an error. This won't exercise template logic like component specs, but will increase confidence where there are incomplete component specs and prevent us shipping variants that don't work (and would cause fractal to break.

4. Run the same smoke tests against the _transpiled_ component templates. For now this is just the packaged nunjucks output (eg, with wrapping `macro` tags). I tried to implement the same kind of test for ERB, but ran into issues with ruby/erb/bindings and how it should follow how `rails` interacts with ERB. It would be nice for the alpha - helping us catch where a transpile has introduced a bug, but not essential. 

