### PR TITLE
Add tests for template escaping in components

### DIFF
--- a/app/components/form-group/form-group.config.js
+++ b/app/components/form-group/form-group.config.js
@@ -6,12 +6,19 @@ module.exports = {
     name: 'full-name',
     label: 'Full name',
     hint: '',
-    error: ''
+    error: '',
+    value: ''
   },
   variants: [{
     name: 'has hint',
     context: {
       hint: 'As shown on your birth certificate or passport'
+    }
+  },
+  {
+    name: 'has value',
+    context: {
+      value: 'Example name'
     }
   },
   {
@@ -30,8 +37,9 @@ module.exports = {
   {
     name: 'textarea',
     context: {
-      isTextarea: 'true'
+      isTextarea: 'true',
+      value: 'Content of text area'
     }
   }],
-  arguments: ['id', 'name', 'label', 'hint', 'error', 'isTextarea']
+  arguments: ['id', 'name', 'label', 'hint', 'error', 'isTextarea', 'value']
 }

--- a/app/components/form-group/form-group.nunj
+++ b/app/components/form-group/form-group.nunj
@@ -9,8 +9,7 @@
     {% endif %}
   </label>
   {% if isTextarea %}
-    <textarea class="gv-c-form-group__control {% if error %}gv-c-form-group__control--has-error{% endif %}" id="{{ id }}" name="{{ name }}" cols="30" rows="5">{{ value}}
-    </textarea>
+    <textarea class="gv-c-form-group__control {% if error %}gv-c-form-group__control--has-error{% endif %}" id="{{ id }}" name="{{ name }}" cols="30" rows="5">{{ value}}</textarea>
   {% endif %}
   {% if not isTextarea %}
     <input class="gv-c-form-group__control {% if error %}gv-c-form-group__control--has-error{% endif %}" id="{{ id }}" name="{{ name }}" value="{{ value }}" type="text">

--- a/app/components/form-group/form-group.nunj
+++ b/app/components/form-group/form-group.nunj
@@ -9,10 +9,10 @@
     {% endif %}
   </label>
   {% if isTextarea %}
-    <textarea class="gv-c-form-group__control {% if error %}gv-c-form-group__control--has-error{% endif %}" id="{{ id }}" name="{{ name }}" cols="30" rows="5">
+    <textarea class="gv-c-form-group__control {% if error %}gv-c-form-group__control--has-error{% endif %}" id="{{ id }}" name="{{ name }}" cols="30" rows="5">{{ value}}
     </textarea>
   {% endif %}
   {% if not isTextarea %}
-    <input class="gv-c-form-group__control {% if error %}gv-c-form-group__control--has-error{% endif %}" id="{{ id }}" name="{{ name }}" value="" type="text">
+    <input class="gv-c-form-group__control {% if error %}gv-c-form-group__control--has-error{% endif %}" id="{{ id }}" name="{{ name }}" value="{{ value }}" type="text">
   {% endif %}
 </div>

--- a/test/specs/components/form_group_spec.js
+++ b/test/specs/components/form_group_spec.js
@@ -17,4 +17,41 @@ describe('Form group component', function () {
       </div>`
     )
   })
+
+  it('should render with a value', () => {
+    expectComponent(
+      'form-group',
+      {
+        'id': 'full-name',
+        'name': 'full-name',
+        'label': 'Full name',
+        'value': 'My example name'
+      },
+      `<div class="gv-c-form-group ">
+        <label class="gv-c-form-group__label" for="full-name">
+          Full name
+        </label>
+        <input class="gv-c-form-group__control " id="full-name" name="full-name" value="My example name" type="text">
+      </div>`
+    )
+  })
+
+  it('should render textarea with a value', () => {
+    expectComponent(
+      'form-group',
+      {
+        'id': 'full-name',
+        'name': 'full-name',
+        'label': 'Full name',
+        'isTextarea': true,
+        'value': 'My example name'
+      },
+      `<div class="gv-c-form-group ">
+        <label class="gv-c-form-group__label" for="full-name">
+          Full name
+        </label>
+        <textarea class="gv-c-form-group__control " id="full-name" name="full-name" cols="30" rows="5">My example name</textarea>
+      </div>`
+    )
+  })
 })

--- a/test/specs/components/form_group_spec.js
+++ b/test/specs/components/form_group_spec.js
@@ -36,6 +36,24 @@ describe('Form group component', function () {
     )
   })
 
+  it('should render with an escaped unsafe value', () => {
+    expectComponent(
+      'form-group',
+      {
+        'id': 'full-name',
+        'name': 'full-name',
+        'label': 'Full name',
+        'value': '"/><script>document.location.href="http://example.com"</script>'
+      },
+      `<div class="gv-c-form-group ">
+        <label class="gv-c-form-group__label" for="full-name">
+          Full name
+        </label>
+        <input class="gv-c-form-group__control " id="full-name" name="full-name" value="&quot;/&gt;&lt;script&gt;document.location.href=&quot;http://example.com&quot;&lt;/script&gt;" type="text">
+      </div>`
+    )
+  })
+
   it('should render textarea with a value', () => {
     expectComponent(
       'form-group',


### PR DESCRIPTION
We want all input to components to be escaped at output time, which is the default in nunjucks.

These tests assert that happens. In testing i discovered that `fractal` has auto-escaping _disabled_, which is inconsistent (and a little bit dangerous). I've raised that with the `fractal` team, and they're going to make it configurable and change the default to be auto-escaped in the next major version.

Once thats in i'm happy with the state of escaping/basic security concerns. As noted in one commit message, this assumes all target templating systems support the same auto-escape behaviour. We'll need to look at a different approach if they don't.