### PR TITLE
Update govuk frontend toolkit to 5.0.2

### DIFF
--- a/app/assets/js/toolkit/govuk/analytics/google-analytics-universal-tracker.js
+++ b/app/assets/js/toolkit/govuk/analytics/google-analytics-universal-tracker.js
@@ -1,6 +1,7 @@
 ;(function (global) {
   'use strict'
 
+  var $ = global.jQuery
   var GOVUK = global.GOVUK || {}
 
   var GoogleAnalyticsUniversalTracker = function (trackingId, fieldsObject) {
@@ -34,24 +35,24 @@
 
   // https://developers.google.com/analytics/devguides/collection/analyticsjs/pages
   GoogleAnalyticsUniversalTracker.prototype.trackPageview = function (path, title, options) {
-    options = options || {}
+    var pageviewObject
 
     if (typeof path === 'string') {
-      var pageviewObject = {
-        page: path
-      }
+      pageviewObject = { page: path }
+    }
 
-      if (typeof title === 'string') {
-        pageviewObject.title = title
-      }
+    if (typeof title === 'string') {
+      pageviewObject = pageviewObject || {}
+      pageviewObject.title = title
+    }
 
-      // Set the transport method for the pageview
-      // Typically used for enabling `navigator.sendBeacon` when the page might be unloading
-      // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport
-      if (options.transport) {
-        pageviewObject.transport = options.transport
-      }
+    // Set an options object for the pageview (e.g. transport, sessionControl)
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport
+    if (typeof options === 'object') {
+      pageviewObject = $.extend(pageviewObject || {}, options)
+    }
 
+    if (!$.isEmptyObject(pageviewObject)) {
       sendToGa('send', 'pageview', pageviewObject)
     } else {
       sendToGa('send', 'pageview')

--- a/app/assets/js/toolkit/govuk/shim-links-with-button-role.js
+++ b/app/assets/js/toolkit/govuk/shim-links-with-button-role.js
@@ -1,13 +1,12 @@
 // javascript 'shim' to trigger the click event of element(s)
 // when the space key is pressed.
 //
-// usage instructions:
-// GOVUK.shimLinksWithButtonRole.init();
+// Created since some Assistive Technologies (for example some Screenreaders)
+// Will tell a user to press space on a 'button', so this functionality needs to be shimmed
+// See https://github.com/alphagov/govuk_elements/pull/272#issuecomment-233028270
 //
-// If you want to customise the shim you can pass in a custom configuration
-// object with your own selector for the target elements and addional keyup
-// codes if there becomes a need to do so. For example:
-// GOVUK.shimLinksWithButtonRole.init({ selector: '[role="button"]' });
+// Usage instructions:
+// GOVUK.shimLinksWithButtonRole.init();
 ;(function (global) {
   'use strict'
 
@@ -16,40 +15,16 @@
 
   GOVUK.shimLinksWithButtonRole = {
 
-    // default configuration that can be overridden by passing object as second parameter to module
-    config: {
-      // the target element(s) to attach the shim event to
-      selector: 'a[role="button"]',
-      // array of keys to match against upon the keyup event
-      keycodes: [
-        32 // spacekey
-      ]
-    },
-
-    // event behaviour (not a typical anonymous function for resuse if needed)
-    triggerClickOnTarget: function triggerClickOnTarget (event) {
-      // if the code from this event is in the keycodes array then
-      if ($.inArray(event.which, this.config.keycodes) !== -1) {
-        event.preventDefault()
-        // trigger the target's click event
-        event.target.click()
-      }
-    },
-
-    // By default this will find all links with role attribute set to
-    // 'button' and will trigger their click event when the space key (32) is pressed.
-    // @method init
-    // @param  {Object}   customConfig                object to override default configuration
-    //         {String}   customConfig.selector       a selector for the elements to be 'clicked'
-    //         {Array}    customConfig.keycodes       an array of javascript keycode values to match against that when pressed will trigger the click
-    init: function init (customConfig) {
-      // extend the default config with any custom attributes passed in
-      this.config = $.extend(this.config, customConfig)
-      // if we have found elements then:
-      if ($(this.config.selector).length > 0) {
-        // listen to 'document' for keyup event on the elements and fire the triggerClickOnTarget
-        $(document).on('keyup', this.config.selector, this.triggerClickOnTarget.bind(this))
-      }
+    init: function init () {
+      // listen to 'document' for keydown event on the any elements that should be buttons.
+      $(document).on('keydown', '[role="button"]', function (event) {
+        // if the keyCode (which) is 32 it's a space, let's simulate a click.
+        if (event.which === 32) {
+          event.preventDefault()
+          // trigger the target's click event
+          event.target.click()
+        }
+      })
     }
 
   }

--- a/app/assets/js/toolkit/govuk/stick-at-top-when-scrolling.js
+++ b/app/assets/js/toolkit/govuk/stick-at-top-when-scrolling.js
@@ -91,6 +91,15 @@
         sticky.$els.each(function (i, el) {
           var $el = $(el)
 
+          var elResize = $el.hasClass('js-sticky-resize')
+          if (elResize) {
+            var $shim = $('.shim')
+            var $elParent = $el.parent('div')
+            var elParentWidth = $elParent.width()
+            $shim.css('width', elParentWidth)
+            $el.css('width', elParentWidth)
+          }
+
           if (windowDimensions.width <= 768) {
             sticky.release($el)
           }

--- a/app/assets/scss/components/_phase-banner.scss
+++ b/app/assets/scss/components/_phase-banner.scss
@@ -2,9 +2,9 @@
 // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/design-patterns/_alpha-beta.scss
 // .phase-banner
 // Usage:
-// <div class="c-phase-banner c-phase-banner--alpha">
+// <div class="c-phase-banner">
 //   <div class="c-phase-banner__content">
-//     <strong class="c-phase-tag c-phase-tag--alpha">ALPHA</strong>
+//     <strong class="c-phase-tag">ALPHA</strong>
 //     <span class="c-phase-banner__text">You can help us improve this app by completing our <a href="https://www.surveymonkey.co.uk/r/2MZRS9H">5 minute survey</a>.</span>
 //   </div>
 // </div>

--- a/app/assets/scss/components/_phase-tag.scss
+++ b/app/assets/scss/components/_phase-tag.scss
@@ -16,12 +16,6 @@
   letter-spacing: 1px;
   text-decoration: none;
 
-  &--alpha {
-    background-color: $alpha-colour;
-  }
-
-  &--beta {
-    background-color: $beta-colour;
-  }
+  background-color: $govuk-blue;
 
 }

--- a/app/assets/scss/settings/_global.scss
+++ b/app/assets/scss/settings/_global.scss
@@ -51,18 +51,18 @@ $path:                false !default;
 // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_font_stack.scss#L7
 // sass-lint:disable variable-name-format
 
-$NTA-Light: "nta", Arial, sans-serif;
-$NTA-Light-Tabular: "ntatabularnumbers", $NTA-Light;
+$nta-light: "nta", Arial, sans-serif;
+$nta-light-tabular: "ntatabularnumbers", $nta-light;
 
 // Helvetica Regular
 // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_font_stack.scss#L11
-$Helvetica-Regular: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
+$helvetica-regular: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
 
 // Allow font stack to be overridden
 // Not all apps using toolkit use New Transport
 // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_font_stack.scss#L15
-$toolkit-font-stack: $NTA-Light !default;
-$toolkit-font-stack-tabular: $NTA-Light-Tabular !default;
+$toolkit-font-stack: $nta-light !default;
+$toolkit-font-stack-tabular: $nta-light-tabular !default;
 
 // Print stylesheets (template)
 // https://github.com/alphagov/govuk_template/blob/master/source/assets/stylesheets/styleguide/_print.scss
@@ -71,3 +71,12 @@ $is-print:          false !default;
 // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_font_stack.scss#L19
 // Font reset for print
 $print-reset:       sans-serif;
+
+// Fallback variable names after renaming previous uppercase names to be lowercase
+// @deprecated, please only use the lowercase versions
+// Make an exception to the linting as these are still used a lot
+// scss-lint:disable NameFormat
+$NTA-Light: $nta-light;
+$NTA-Light-Tabular: $nta-light-tabular;
+$Helvetica-Regular: $helvetica-regular;
+$Print-reset: $print-reset;

--- a/test/specs/toolkit/unit/shim-links-with-button-role.spec.js
+++ b/test/specs/toolkit/unit/shim-links-with-button-role.spec.js
@@ -7,7 +7,7 @@ describe('shim-links-with-button-role', function () {
   var GOVUK = window.GOVUK
 
   var $buttonLink
-  var keyupEvent
+  var keyDownEvent
 
   beforeEach(function () {
     $buttonLink = $('<a role="button">Button</a>')
@@ -15,8 +15,8 @@ describe('shim-links-with-button-role', function () {
       $buttonLink.addClass('clicked')
     })
     $(document.body).append($buttonLink)
-    keyupEvent = $.Event('keyup')
-    keyupEvent.target = $buttonLink.get(0)
+    keyDownEvent = $.Event('keydown')
+    keyDownEvent.target = $buttonLink.get(0)
     GOVUK.shimLinksWithButtonRole.init()
   })
 
@@ -28,14 +28,14 @@ describe('shim-links-with-button-role', function () {
   it('should trigger event on space', function () {
     // Ideally we’d test the page loading functionality but that seems hard to
     // do within a Jasmine context. Settle for checking a bound event trigger.
-    keyupEvent.which = 32 // Space character
-    $(document).trigger(keyupEvent)
+    keyDownEvent.which = 32 // Space character
+    $(document).trigger(keyDownEvent)
     expect($buttonLink.hasClass('clicked')).toBe(true)
   })
 
   it('should not trigger event on tab', function () {
-    keyupEvent.which = 9 // Tab character
-    $(document).trigger(keyupEvent)
+    keyDownEvent.which = 9 // Tab character
+    $(document).trigger(keyDownEvent)
     expect($buttonLink.hasClass('clicked')).toBe(false)
   })
 })


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

### What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds the GOV.UK Frontend toolkit as a dev dependency in order to update its assets.

#### What does it do?
<!--- Describe your changes -->

The govuk_frontend_toolkit is added to package.json.

A Gulp task is added to copy the js from node_modues/ to app/.

It also includes manually copied changes to the scss files:
- the phase banner is now $govuk-blue
- the variable names for fonts are updated to be lowercase, with mappings to their previous names. 


#### Screenshots (if appropriate):

#### What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
