### PR TITLE
Add styles and javascript for custom form controls

### DIFF
--- a/app/assets/scss/components/_form-custom.scss
+++ b/app/assets/scss/components/_form-custom.scss
@@ -1,78 +1,142 @@
+// Large hit area
+// Radio buttons & checkboxes
+
+// By default, block labels stack vertically
 .gv-c-form-custom {
 
-  @include media(mobile) {
-    float: none;
-    clear: left;
-  }
-
   display: block;
-
+  float: none;
+  clear: left;
   position: relative;
 
-  background: $panel-colour;
-  border: 1px solid $panel-colour;
-  padding: (18px $gutter $gutter-half $gutter * 1.8);
+  padding: (8px $gutter-one-third 9px 50px);
+  margin-bottom: $gutter-one-third;
 
-  margin-bottom: 10px;
   cursor: pointer; // Encourage clicking on block labels
 
-  // States
-  // Using .selected here as this is set by selection-buttons.js
-  &.selected,
-  // Ideally we'd use a state class, e.g. .is-selected
-  &.is-selected {
-    background: $white;
-    border-color: $black;
-  }
+  // remove 300ms pause on mobile
+  -ms-touch-action: manipulation;
+  touch-action: manipulation;
 
-  // Using .focused here as this is set by selection-buttons.js
-  &.focused,
-  // Ideally we'd use a state class, e.g. .has-focus, or is-focused
-  &.is-focused {
-    outline: $width-focus-outline solid $focus-colour;
+  @include media(tablet) {
+    float: left;
+    padding-top: 7px;
+    padding-bottom: 7px;
+    // width: 25%; - Test : check that text within labels will wrap
   }
 
   // Absolutely position inputs within label, to allow text to wrap
   &__control {
     position: absolute;
-    top: 15px;
-    left: $gutter-half;
     cursor: pointer;
-    margin: 0;
-    width: 29px;
-    height: 29px;
+    left: 0;
+    top: 0;
+    width: 38px;
+    height: 38px;
 
-    @include ie(8) {
-      top: 12px;
+    // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there.
+    @if ($is-ie == false) or ($ie-version == 9) {
+      .js-enabled & {
+        margin: 0;
+        @include opacity(0);
+      }
     }
-
-    // Don't add an outline here
-    outline: 0 !important;
-
-    // Change border on hover
-    &:hover {
-      border-color: $black;
-    }
-
   }
 
-  // To stack horizontally, use .--inline, to sit block labels next to each other
-  // &--inline {
-  //   clear: none;
-  //   @include media (tablet) {
-  //     margin-bottom: 0;
-  //     margin-right: 10px;
-  //   }
-  // }
-  // TODO:
-  // Use these for custom radios and checkboxes
-  // &--radio {
-  // }
-  // &--checkbox {
-  // }
+  .js-enabled & {
+    &.selection-button-radio::before {
+      content: "";
+      border: 2px solid;
+      background: transparent;
+      width: 34px;
+      height: 34px;
+      position: absolute;
+      top: 0;
+      left: 0;
+      @include border-radius(50%);
+    }
 
+    &.selection-button-radio::after {
+      content: "";
+      border: 10px solid;
+      width: 0;
+      height: 0;
+      position: absolute;
+      top: 9px;
+      left: 9px;
+      @include border-radius(50%);
+      @include opacity(0);
+    }
+
+    &.selection-button-checkbox::before {
+      content: "";
+      border: 2px solid;
+      background: transparent;
+      width: 34px;
+      height: 34px;
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
+
+    &.selection-button-checkbox::after {
+      content: "";
+      border: solid;
+      border-width: 0 0 5px 5px;
+      background: transparent;
+      width: 17px;
+      height: 7px;
+      position: absolute;
+      top: 10px;
+      left: 8px;
+      -moz-transform: rotate(-45deg); // Firefox 15 compatibility
+      -o-transform: rotate(-45deg); // Opera 12.0 compatibility
+      -webkit-transform: rotate(-45deg); // Safari 8 compatibility
+      -ms-transform: rotate(-45deg); // IE9 compatibility
+      transform: rotate(-45deg);
+      @include opacity(0);
+    }
+
+    // Focused state
+    &.selection-button-radio,
+    &.selection-button-checkbox {
+      &.focused::before {
+        @include box-shadow(0 0 0 5px $focus-colour);
+      }
+      // IE8 focus outline should stay as a border around the entire label
+      // Lack of padding doesn’t matter as IE8 won’t resize the inputs.
+      @include ie-lte(8) {
+        &.focused {
+          outline: 3px solid $focus-colour;
+
+          input:focus {
+            outline: none;
+          }
+        }
+      }
+    }
+
+    // Selected state
+    &.selection-button-radio,
+    &.selection-button-checkbox {
+      &.selected::after {
+        @include opacity(1);
+      }
+    }
+  }
+
+  &:last-child,
+  &:last-of-type {
+    margin-bottom: 0;
+  }
 }
 
-.gv-c-form-custom:last-child {
-  margin-bottom: 0;
+// To stack horizontally, use .inline on parent, to sit block labels next to each other
+.inline .block-label {
+  clear: none;
+
+  @include media (tablet) {
+    margin-bottom: 0;
+    margin-right: $gutter;
+  }
 }

--- a/app/assets/scss/components/_form-group.scss
+++ b/app/assets/scss/components/_form-group.scss
@@ -63,9 +63,9 @@
   @include core-19;
   width: 100%;
 
-  padding: 4px;
-  background-color: $white;
-  border: 2px solid $grey-1;
+  padding: 5px 4px 4px;
+  background-color: transparent;
+  border: 2px solid;
 }
 
 .gv-c-form-group__control--has-error {

--- a/app/components/_preview.nunj
+++ b/app/components/_preview.nunj
@@ -13,4 +13,18 @@
 <body>
   {{ yield }}
 </body>
+<script src="{{ '/javascripts/elements/vendor/jquery-1.11.0.min.js' | path }}"></script>
+<script src="{{ '/javascripts/govuk-template.min.js' | path }}"></script>
+<script src="{{ '/javascripts/toolkit.min.js' | path }}"></script>
+<script src="{{ '/javascripts/elements.min.js' | path }}"></script>
+<script>
+  $(document).ready(function () {
+    // govuk_template sets this, we're not loading the template as a wrapper for components so set it here
+    $('body').addClass('js-enabled')
+    // Use GOV.UK selection-buttons.js to set selected
+    // and focused states for block labels
+    var $blockLabels = $(".gv-c-form-custom input[type='radio'], .gv-c-form-custom input[type='checkbox']")
+    new GOVUK.SelectionButtons($blockLabels)
+  })
+</script>
 </html>

--- a/app/components/form-radio-group/form-radio-group.initialise.js
+++ b/app/components/form-radio-group/form-radio-group.initialise.js
@@ -1,0 +1,8 @@
+$(document).ready(function () {
+  // govuk_template sets this, we're not loading the template as a wrapper for components so set it here
+  $('body').addClass('js-enabled')
+  // Use GOV.UK selection-buttons.js to set selected
+  // and focused states for block labels
+  var $blockLabels = $(".gv-c-form-custom input[type='radio'], .gv-c-form-custom input[type='checkbox']")
+  new GOVUK.SelectionButtons($blockLabels) // eslint-disable-line
+})

--- a/app/components/form-radio-group/form-radio-group.nunj
+++ b/app/components/form-radio-group/form-radio-group.nunj
@@ -12,7 +12,7 @@
     </legend>
 
     {% for radio in radioGroup %}
-      <label class="gv-c-form-custom" for="{{radio.id}}">
+      <label class="gv-c-form-custom selection-button-radio" for="{{radio.id}}">
         <input class="gv-c-form-custom__control"
                id="{{radio.id}}"
                type="radio"

--- a/test/specs/components/form_radio_group_spec.js
+++ b/test/specs/components/form_radio_group_spec.js
@@ -31,13 +31,13 @@ describe('Form radio group component', function () {
           <legend>
             <span class="gv-c-form-group__label">How do you want to be contacted?</span>
           </legend>
-          <label class="gv-c-form-custom" for="example-contact-by-email">
+          <label class="gv-c-form-custom selection-button-radio" for="example-contact-by-email">
             <input class="gv-c-form-custom__control" id="example-contact-by-email"
             type="radio" name="contact" value="contact-by-email">Email</label>
-          <label class="gv-c-form-custom" for="example-contact-by-phone">
+          <label class="gv-c-form-custom selection-button-radio" for="example-contact-by-phone">
             <input class="gv-c-form-custom__control" id="example-contact-by-phone"
             type="radio" name="contact" value="contact-by-phone">Phone</label>
-          <label class="gv-c-form-custom" for="example-contact-by-text">
+          <label class="gv-c-form-custom selection-button-radio" for="example-contact-by-text">
             <input class="gv-c-form-custom__control" id="example-contact-by-text"
             type="radio" name="contact" value="contact-by-text">Text</label>
         </fieldset>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

## What problem does the pull request solve?
<!--- Why is this change required? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Update the Sass files for the `.gv-c-form-custom` component, to use the latest styles for custom radio buttons and checkboxes from GOV.UK elements.

Load jQuery, and *all the js* in the preview layout, in future this will be split out - but for now, it's enough to get the component previews working.

There's one caveat to this PR, the selection-buttons.js requires a parent `<form>` element in order for it to work. We don't want to wrap the custom radio component in a form element, but we'll need to find a way for a component to sit within a preview layout that includes this.

Screenshots (if appropriate):

Before:

![radio buttons before](https://cloud.githubusercontent.com/assets/417754/21105555/8cb72c28-c082-11e6-86d0-0b0cf7ac4c83.png)

After:

![radio buttons after](https://cloud.githubusercontent.com/assets/417754/21105562/947a18b2-c082-11e6-8ce9-5205ac4651bd.png)

## What type of change is it?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- New feature (non-breaking change which adds functionality)

