### PR TITLE
Show all component variants as navigation items

### DIFF
--- a/fractal/config/fractal.js
+++ b/fractal/config/fractal.js
@@ -22,8 +22,8 @@ fractal.components.engine(nunjucks)
 // Specify a preview layout for a component
 fractal.components.set('default.preview', '@preview')
 
-// Variants should default to being collated in rendered previews
-fractal.components.set('default.collated', true)
+// Don't collate variants for rendered previews
+fractal.components.set('default.collated', false)
 
 // Set a default status for all components (TODO: default to WIP?)
 // fractal.components.set('default.status', null);

--- a/fractal/govuk-theme/assets/scss/_theme-overrides.scss
+++ b/fractal/govuk-theme/assets/scss/_theme-overrides.scss
@@ -38,6 +38,7 @@ a:active {
   letter-spacing: normal;
 }
 
+// Sidebar section title
 .Tree-title {
   color: $secondary-text-colour;
   text-transform: none;
@@ -46,8 +47,15 @@ a:active {
   margin-bottom: 0.75em;
 }
 
+// Component name
+.Tree-collectionLabel {
+  @include core-16;
+  color: $text-colour;
+}
+
+// Left hand navigation item
 .Tree-entityLink {
-  @include bold-16;
+  @include core-16;
   padding-top: 0.5rem;
   padding-bottom: 0.4rem;
 }


### PR DESCRIPTION
Don't collate variants by default, instead have these appear as nested options in the left hand navigation.

Adjust left hand navigation styling.

Before:

![before](https://cloud.githubusercontent.com/assets/417754/21110095/d719b9aa-c093-11e6-9a2d-f07577034334.png)

After:

![after](https://cloud.githubusercontent.com/assets/417754/21110079/bf9a6a18-c093-11e6-801a-291a08f8f298.png)

