### PR TITLE
Fix Rails component packaging to use right file name

### DIFF
--- a/lib/tasks/package-gem.js
+++ b/lib/tasks/package-gem.js
@@ -21,9 +21,11 @@ gulp.task('package:gem:prepare', () => {
   gulp.src(paths.bundleJs + '**/*').pipe(gulp.dest(paths.gemJs))
   gulp.src(paths.bundleTemplates + '**/*').pipe(gulp.dest(paths.gemTemplates))
 
-  // Partials require a _ prefix
   gulp.src(paths.bundleComponents + '**/*')
-    .pipe(rename({prefix: '_'}))
+    .pipe(rename(path => {
+    // Partials files require a _ prefix, and use underscores, not dashes
+      path.basename = '_' + path.basename.replace('-', '_')
+    }))
     .pipe(gulp.dest(paths.gemComponents))
 
   gulp.src(`lib/packaging/gem/${packageJson.name}.gemspec`).pipe(gulp.dest(paths.gem))


### PR DESCRIPTION
This was working for single word components (button), but for dash
separated components like form-group Rails will error if a partial
name has dashes in it, and need to be underscores instead.