### PR TITLE
Add phase-banner component, and an example of unescaped component input

### DIFF
--- a/app/components/phase-banner/README.md
+++ b/app/components/phase-banner/README.md
@@ -1,0 +1,5 @@
+# Phase Banner
+
+Copied from [GOV.UK Elements](http://govuk-elements.herokuapp.com/alpha-beta-banners/).
+
+You have to use an alpha banner if your thing is in alpha, and a beta banner if it’s in beta.

--- a/app/components/phase-banner/phase-banner.config.js
+++ b/app/components/phase-banner/phase-banner.config.js
@@ -14,6 +14,13 @@ module.exports = {
       phase: 'beta',
       message: 'This service is in Beta – your feedback will help us to improve it.'
     }
+  },
+  {
+    name: 'message_html',
+    context: {
+      phase: 'beta',
+      message_html: 'This service is new – your <a href="#">feedback</a> will help us to improve it.'
+    }
   }],
   arguments: ['phase', 'message']
 }

--- a/app/components/phase-banner/phase-banner.config.js
+++ b/app/components/phase-banner/phase-banner.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  title: 'Phase Banner',
+  status: 'wip',
+  variants: [{
+    name: 'default',
+    context: {
+      phase: 'alpha',
+      message: 'This is a new service – your feedback will help us to improve it.'
+    }
+  },
+  {
+    name: 'beta',
+    context: {
+      phase: 'beta',
+      message: 'This service is in Beta – your feedback will help us to improve it.'
+    }
+  }],
+  arguments: ['phase', 'message']
+}

--- a/app/components/phase-banner/phase-banner.nunj
+++ b/app/components/phase-banner/phase-banner.nunj
@@ -1,6 +1,6 @@
 <div class="gv-c-phase-banner">
   <p class="gv-c-phase-banner__content">
     <strong class="gv-c-phase-tag">{{ phase }}</strong>
-    <span class="gv-c-phase-banner__text">{{ message }}</span>
+    <span class="gv-c-phase-banner__text">{% if message %}{{ message }}{% else %}{{ message_html|safe }}{% endif %}</span>
   </p>
 </div>

--- a/app/components/phase-banner/phase-banner.nunj
+++ b/app/components/phase-banner/phase-banner.nunj
@@ -1,0 +1,6 @@
+<div class="gv-c-phase-banner">
+  <p class="gv-c-phase-banner__content">
+    <strong class="gv-c-phase-tag">{{ phase }}</strong>
+    <span class="gv-c-phase-banner__text">{{ message }}</span>
+  </p>
+</div>

--- a/test/specs/components/phase_banner_spec.js
+++ b/test/specs/components/phase_banner_spec.js
@@ -30,4 +30,19 @@ describe('Phase banner component', function () {
       </div>`
     )
   })
+
+  it('should allow trusted a HTML message', function () {
+    expectComponent(
+      'phase-banner',
+      {
+        phase: 'beta',
+        message_html: 'This service is new  – your <a href="#">feedback</a> will help us to improve it.'
+      },
+      `<div class="gv-c-phase-banner">
+        <p class="gv-c-phase-banner__content"> <strong class="gv-c-phase-tag">beta</strong>
+          <span class="gv-c-phase-banner__text">This service is new  – your <a href="#">feedback</a> will help us to improve it.</span>
+        </p>
+      </div>`
+    )
+  })
 })

--- a/test/specs/components/phase_banner_spec.js
+++ b/test/specs/components/phase_banner_spec.js
@@ -1,0 +1,33 @@
+const expectComponent = require('./helper').expectComponent
+
+describe('Phase banner component', function () {
+  it('should render', () => {
+    expectComponent(
+      'phase-banner',
+      {
+        phase: 'Alpha',
+        message: 'This is a new service – your feedback will help us to improve it.'
+      },
+      `<div class="gv-c-phase-banner">
+        <p class="gv-c-phase-banner__content"> <strong class="gv-c-phase-tag">Alpha</strong>
+          <span class="gv-c-phase-banner__text">This is a new service – your feedback will help us to improve it.</span>
+        </p>
+      </div>`
+    )
+  })
+
+  it('should render beta', function () {
+    expectComponent(
+      'phase-banner',
+      {
+        phase: 'beta',
+        message: 'This service is in Beta – your feedback will help us to improve it.'
+      },
+      `<div class="gv-c-phase-banner">
+        <p class="gv-c-phase-banner__content"> <strong class="gv-c-phase-tag">beta</strong>
+          <span class="gv-c-phase-banner__text">This service is in Beta – your feedback will help us to improve it.</span>
+        </p>
+      </div>`
+    )
+  })
+})


### PR DESCRIPTION
This is a good example of adding a component from scratch, and was easy to do. Basic component built in a couple of minutes, tested against specs and a live-updating fractal. Worked well.

Used `message` as the param name, as that made more sense from an API perspective, but doesn't match the BEM naming. Doesn't matter in this case, I don't think, but would consistency there be useful?

A common use for the phase banner is soliciting feedback via a link, so this allow the component to take a message containing HTML, that isn't escaped (as is the default in nunjucks). The `safe` filter has an ERB equivilent in `raw` that i'm adding support for in `meta-template`

![screen shot 2016-12-13 at 14 32 35](https://cloud.githubusercontent.com/assets/63201/21144047/0beacc3e-c141-11e6-86d2-1197be3878af.png)

With the ERB/meta-template tweaking i'd feel more comfortable with some kind of [integration test](https://github.com/alphagov/govuk_frontend_alpha/pull/81) for the erb output, as a nunjucks filter could be introduced thats not supported, but we can't do that easily right now :/