### PR TITLE
Make mocha specs use arrow functions

### DIFF
--- a/test/specs/components/button_spec.js
+++ b/test/specs/components/button_spec.js
@@ -1,6 +1,6 @@
 const expectComponent = require('./helper').expectComponent
 
-describe('Button component', function () {
+describe('Button component', () => {
   it('should render', () => {
     expectComponent(
       'button',

--- a/test/specs/components/form_group_spec.js
+++ b/test/specs/components/form_group_spec.js
@@ -1,6 +1,6 @@
 const expectComponent = require('./helper').expectComponent
 
-describe('Form group component', function () {
+describe('Form group component', () => {
   it('should render', () => {
     expectComponent(
       'form-group',

--- a/test/specs/components/form_radio_group_spec.js
+++ b/test/specs/components/form_radio_group_spec.js
@@ -1,6 +1,6 @@
 const expectComponent = require('./helper').expectComponent
 
-describe('Form radio group component', function () {
+describe('Form radio group component', () => {
   it('should render', () => {
     expectComponent(
       'form-radio-group',

--- a/test/specs/components/phase_banner_spec.js
+++ b/test/specs/components/phase_banner_spec.js
@@ -1,6 +1,6 @@
 const expectComponent = require('./helper').expectComponent
 
-describe('Phase banner component', function () {
+describe('Phase banner component', () => {
   it('should render', () => {
     expectComponent(
       'phase-banner',

--- a/test/specs/components/smoke_spec.js
+++ b/test/specs/components/smoke_spec.js
@@ -9,7 +9,7 @@ const expectComponentRenders = (name, input) => {
   }).to.not.throw()
 }
 
-describe('Components render examples without errors', function () {
+describe('Components render examples without errors', () => {
   Object.keys(components.all).map(name => {
     it(`${name} component renders all variants without errors`, () => {
       let component = components.get(name)

--- a/test/specs/fractal_spec.js
+++ b/test/specs/fractal_spec.js
@@ -6,7 +6,7 @@ const assert = require('assert')
 // Check that everything is in place for Fractal to run
 
 // Check the build tasks has copied the assets to public
-describe('the build task', function () {
+describe('the build task', () => {
   it('should copy assets into the /public directory', function () {
     assert.doesNotThrow(function () {
       fs.accessSync(path.resolve(__dirname, '../../public/javascripts/elements.js'))
@@ -22,7 +22,7 @@ describe('the build task', function () {
 })
 
 // Check the theme tasks has compiled the theme stylesheet
-describe('the theme task', function () {
+describe('the theme task', () => {
   it('should compile the sass to css in the /fractal/govuk-theme directory', function () {
     assert.doesNotThrow(function () {
       fs.accessSync(path.resolve(__dirname, '../../fractal/govuk-theme/assets/css/fractal-govuk-theme.css'))

--- a/test/specs/preview_spec.js
+++ b/test/specs/preview_spec.js
@@ -6,8 +6,8 @@ const fs = require('fs')
 const assert = require('assert')
 
 // Check that assets are copied and the app runs
-describe('Copy assets to public and run the app...', function () {
-  describe('the preview task', function () {
+describe('Copy assets to public and run the app...', () => {
+  describe('the preview task', () => {
     it('should copy assets into the /public folder', function () {
       assert.doesNotThrow(function () {
         fs.accessSync(path.resolve(__dirname, '../../public/javascripts/elements.js'))
@@ -22,7 +22,7 @@ describe('Copy assets to public and run the app...', function () {
     })
   })
 
-  describe('the index page', function () {
+  describe('the index page', () => {
     it('should return a 200 on a get to "/"', function (done) {
       request(app)
         .get('/')

--- a/test/specs/transpiler_spec.js
+++ b/test/specs/transpiler_spec.js
@@ -20,7 +20,7 @@ const nunjucksAssetVersion = '1.0.0'
 const nunjucksTextFor = `<a href="#content" class="skiplink">{{ skip_link_message|default('Skip to main content') }}</a>`
 const nunjucksBlockFor = `{% block top_of_page %}{% endblock %}`
 
-describe('Transpilation', function () {
+describe('Transpilation', () => {
   it('should return a Buffer', function (done) {
     let inputFile = new File({contents: new Buffer('test')})
     let testTranspiler = transpiler.transpileTemplate('erb', nunjucksAssetVersion)
@@ -31,7 +31,7 @@ describe('Transpilation', function () {
     })
   })
 
-  describe('into Nunjucks', function () {
+  describe('into Nunjucks', () => {
     let nunjucksTranspiler
 
     beforeEach(function () {
@@ -50,7 +50,7 @@ describe('Transpilation', function () {
     })
   })
 
-  describe('into ERB', function () {
+  describe('into ERB', () => {
     let erbTranspiler
 
     beforeEach(function () {
@@ -86,7 +86,7 @@ describe('Transpilation', function () {
     })
   })
 
-  describe('into Handlebars', function () {
+  describe('into Handlebars', () => {
     let handlebarsTranspiler
 
     beforeEach(function () {
@@ -107,7 +107,7 @@ describe('Transpilation', function () {
     })
   })
 
-  describe('into Django', function () {
+  describe('into Django', () => {
     let djangoTranspiler
 
     beforeEach(function () {
@@ -128,7 +128,7 @@ describe('Transpilation', function () {
     })
   })
 
-  describe('Component transpilation equivalence', function () {
+  describe('Component transpilation equivalence', () => {
     const allComponents = components.all
 
     Object.keys(allComponents).map(name => {
@@ -136,7 +136,7 @@ describe('Transpilation', function () {
       const sourcePath = components.templatePathFor(name)
       const expected = nunjucks.render(sourcePath, component.context)
 
-      describe('into Nunjucks', function () {
+      describe('into Nunjucks', () => {
         it(`${name} should have the same output after transpile`, function () {
           let transpiledTemplate = transpiler.transpileComponentSync('nunjucks', name, fs.readFileSync(sourcePath).toString())
           let invocation = `{{ ${changeCase.camelCase(name)}(${component.arguments.join(', ')}) }}`


### PR DESCRIPTION
Ref: https://github.com/alphagov/govuk_frontend_alpha/pull/96#pullrequestreview-12691258

Neater, more es-6-y. Consistent with how we're writing functions in
the rest of the repo. Note, excludes the FET specs by design