### PR TITLE
[wip] Show styled components within the docs

### DIFF
--- a/app/docs/elements/button.md
+++ b/app/docs/elements/button.md
@@ -1,0 +1,22 @@
+# Buttons
+
+## Use buttons to move though a transaction, aim to use only one button per page.
+
+### Button text
+
+Button text should be short and describe the action the button performs.
+
+<input class="gv-c-button" type="submit" value="Save and continue">
+
+### Button alignment
+
+Align the primary action button to the left edge of your form, in the user’s line of sight.
+
+Disabled buttons
+
+- don’t disable buttons, unless there’s a good reason to
+- if you have to disable buttons, make sure they look like you can’t click them (use 50% opacity)
+- an example of a useful disabled option is a calendar with greyed out days where no bookings are available
+- provide another way for the user to continue, add an error message or text to explain why the button is disabled
+
+<input class="button" type="submit" value="Save and continue" disabled="disabled">

--- a/app/docs/elements/button.md
+++ b/app/docs/elements/button.md
@@ -6,7 +6,7 @@
 
 Button text should be short and describe the action the button performs.
 
-<input class="gv-c-button" type="submit" value="Save and continue">
+{% render '@button' %}
 
 ### Button alignment
 

--- a/app/docs/elements/button.md
+++ b/app/docs/elements/button.md
@@ -1,3 +1,5 @@
+<link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-frontend.css' | path }}">
+
 # Buttons
 
 ## Use buttons to move though a transaction, aim to use only one button per page.


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

#### What does it do?
<!--- Describe your changes -->

I'd like a way to render a component wrapped in a preview layout (as a way to load a stylesheet for that component) within the documentation. Ideally this would be as an iframe, in the same way as how components are displayed elsewhere.

As a kludge, here I'm using `{% render '@button' %}` to include the component markup - but this documentation file doesn't include the application stylesheet. 

I've included this at the top of the markdown file. The isn't what we want as the the styles for the app then override the Fractal theme styling, using an iframe would ensure the component styles are isolated from the theme styles.

Has anyone else run into this? I'm sure I'm missing something obvious. 

#### Screenshots (if appropriate):

![include component styles in docs](https://cloud.githubusercontent.com/assets/417754/21255197/3e9d75d2-c362-11e6-9f33-953946e3c156.png)
