### PR TITLE
Alpha-only hack for component previews in docs

### DIFF
--- a/app/docs/elements/button.md
+++ b/app/docs/elements/button.md
@@ -1,0 +1,22 @@
+# Buttons
+
+## Use buttons to move though a transaction, aim to use only one button per page.
+
+### Button text
+
+Button text should be short and describe the action the button performs.
+
+<input class="gv-c-button" type="submit" value="Save and continue">
+
+### Button alignment
+
+Align the primary action button to the left edge of your form, in the user’s line of sight.
+
+Disabled buttons
+
+- don’t disable buttons, unless there’s a good reason to
+- if you have to disable buttons, make sure they look like you can’t click them (use 50% opacity)
+- an example of a useful disabled option is a calendar with greyed out days where no bookings are available
+- provide another way for the user to continue, add an error message or text to explain why the button is disabled
+
+<input class="button" type="submit" value="Save and continue" disabled="disabled">

--- a/app/docs/elements/button.md
+++ b/app/docs/elements/button.md
@@ -6,7 +6,7 @@
 
 Button text should be short and describe the action the button performs.
 
-<input class="gv-c-button" type="submit" value="Save and continue">
+{% render '@button' %}
 
 ### Button alignment
 

--- a/app/docs/elements/button.md
+++ b/app/docs/elements/button.md
@@ -1,4 +1,3 @@
-<link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-frontend.css' | path }}">
 
 # Buttons
 
@@ -8,7 +7,15 @@
 
 Button text should be short and describe the action the button performs.
 
-{% render '@button' %}
+{{ '@button'|preview(60) }}
+
+```nunj
+{% view '@button' %}
+```
+
+```json
+{% context '@button' %}
+```
 
 ### Button alignment
 
@@ -21,4 +28,6 @@ Disabled buttons
 - an example of a useful disabled option is a calendar with greyed out days where no bookings are available
 - provide another way for the user to continue, add an error message or text to explain why the button is disabled
 
+```html
 <input class="button" type="submit" value="Save and continue" disabled="disabled">
+```

--- a/app/docs/elements/button.md
+++ b/app/docs/elements/button.md
@@ -1,3 +1,5 @@
+<link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-frontend.css' | path }}">
+
 # Buttons
 
 ## Use buttons to move though a transaction, aim to use only one button per page.

--- a/fractal/config/fractal.js
+++ b/fractal/config/fractal.js
@@ -38,7 +38,9 @@ fractal.components.set('path', paths.appComponents)
 ----------------------------------------------------------------------------- */
 
 // Load the Nunjucks template engine
-fractal.docs.engine(nunjucks)
+fractal.docs.engine(nunjucks({
+  filters: require('../extensions').filters
+}))
 
 // Set the file extension for documentation files
 fractal.docs.set('ext', '.md')

--- a/fractal/extensions/index.js
+++ b/fractal/extensions/index.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const preview = (handle, height) => {
+  // @FIXME: Alpha-only hack to allow component previews in documentation,
+  // should not be used in beta, doesn't support RWD, or component interaction
+  // @TODO: Ideally this would be an extension `{% render 'handle' %}`, but
+  // couldn't get that working quicky, and this is short term anyway.
+  return `<iframe
+    class="InlinePreview-iframe" data-role="window"
+    src="/components/preview/${handle.substring(1)}"
+    sandbox="allow-same-origin allow-scripts"
+    marginwidth="0"
+    marginheight="0"
+    frameborder="0"
+    vspace="0"
+    hspace="0"
+    scrolling="yes"
+    style="
+      height: ${height}px;
+      width: 100%;
+      margin: 0;
+      padding: 10px;
+      border: 1px solid #ccc;
+    "></iframe>`
+}
+
+module.exports.filters = {
+  'preview': preview
+}


### PR DESCRIPTION
Should not be used in beta, doesn't support RWD, or component interaction. But allows us to test/research documentation with embedded previews, like GOV.UK Elements and see if it's useful first.

Longer term solutions were discussed on GH, history here: #104

Ideally this would be an extension `{% render 'handle' %}`, but I couldn't get that working quickly, and this is short term anyway.

Issues:
- height of the iframe is manually set and won't scale for varied components
- auto sizing frames based on the height of their contents is possible, but
  has issues, like that happening after load the page juddering, or what
  happens if an interaction with a component changes height

Additional downside; this approach doesn't allow arbitrary component examples
(like the removed `disabled` button variant). I think to do that
properly we'd need to have `disabled` variants in the config, but
prevent those from being shown in the component view - or something
similar?