### PR TITLE
Reorder the docs section within Fractal, copy content from govuk elements

### DIFF
--- a/app/docs/01-index.md
+++ b/app/docs/01-index.md
@@ -3,3 +3,5 @@ title: GOV.UK Frontend Alpha
 ---
 
 This is the component library for the GOV.UK Frontend Alpha
+
+[Download]()

--- a/app/docs/02-get-started.md
+++ b/app/docs/02-get-started.md
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK Frontend Alpha
 context:
-  section: Download
+  section: Get Started
 ---
 
 # {{ section }}

--- a/app/docs/04-get-started.md
+++ b/app/docs/04-get-started.md
@@ -1,7 +1,0 @@
----
-title: GOV.UK Frontend Alpha
-context:
-  section: Get Started
----
-
-# Get Started

--- a/app/docs/elements/01-layout/01-index.md
+++ b/app/docs/elements/01-layout/01-index.md
@@ -1,0 +1,34 @@
+---
+title: Layout
+context:
+  lede: Use white space to create a visual hierarchy on the page.
+---
+
+{{ lede }}
+
+## Page width
+
+The default maximum page width is 1020px, but go wider if the content requires it.
+
+Use a grid to lay out your content. To prevent long lines of text, content should sit in a column which is two-thirds of the page width.
+
+Long lines reduce legibility, so all lines of text should be no longer than 70 to 80 characters.
+
+## Screen size
+
+Design for small screens first using a single column layout.
+
+Optimise for different screen sizes, but don’t make assumptions about what devices people are using.
+
+## Spacing
+
+* spacing between elements is usually 5px, 10px, 15px or multiples of 15px
+* gutters are 15px for smaller screens and 30px for larger screen
+
+```
+TODO: Fix spacing examples
+```
+
+![alt text](http://govuk-elements.herokuapp.com/public/images/examples/15px-gutter-example.png "15px gutter example")
+
+![alt text](http://govuk-elements.herokuapp.com/public/images/examples/30px-gutter-example.png "30px gutter example")

--- a/app/docs/elements/01-layout/02-grid.md
+++ b/app/docs/elements/01-layout/02-grid.md
@@ -1,0 +1,225 @@
+---
+title: Grid
+---
+
+## Grid unit proportions
+
+* introduce columns as the content requires it – base column ratios on halves, thirds or quarters of the page width
+* for screen breakpoints use media queries – find these in the GOV.UK frontend toolkit _conditionals.scss file
+
+## Grid
+
+```
+TODO: [Insert grid layout example from here](http://govuk-elements.herokuapp.com/layout/example-grid-layout/)
+```
+
+```html
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h2 class="bold-medium">Two thirds</h2>
+    <div class="text">
+      <p>
+        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+      </p>
+      <p>
+        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+      </p>
+    </div>
+  </div>
+  <div class="column-one-third">
+    <h2 class="bold-medium">One third</h2>
+    <p>
+      This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+    </p>
+  </div>
+</div>
+<div class="grid-row">
+  <div class="column-one-third">
+    <h2 class="bold-medium">One third</h2>
+    <p>
+      This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+    </p>
+  </div>
+  <div class="column-one-third">
+    <h2 class="bold-medium">One third</h2>
+    <p>
+      This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+    </p>
+  </div>
+  <div class="column-one-third">
+    <h2 class="bold-medium">One third</h2>
+    <p>
+      This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+    </p>
+  </div>
+</div>
+<div class="grid-row">
+  <div class="column-one-half">
+    <h2 class="bold-medium">One half</h2>
+    <p>
+      This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+    </p>
+  </div>
+  <div class="column-one-half">
+    <h2 class="bold-medium">One half</h2>
+    <p>
+      This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+    </p>
+  </div>
+</div>
+<div class="grid-row">
+  <div class="column-one-half">
+    <h2 class="bold-medium">One half</h2>
+    <p>
+      This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+    </p>
+  </div>
+  <div class="column-one-quarter">
+    <h2 class="bold-medium">One quarter</h2>
+    <p>
+      This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+    </p>
+  </div>
+  <div class="column-one-quarter">
+    <h2 class="bold-medium">One quarter</h2>
+    <p>
+      This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+    </p>
+  </div>
+</div>
+<div class="grid-row">
+  <div class="column-one-quarter">
+    <h2 class="bold-medium">One quarter</h2>
+    <p>
+      This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+    </p>
+  </div>
+  <div class="column-one-quarter">
+    <h2 class="bold-medium">One quarter</h2>
+    <p>
+      This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+    </p>
+  </div>
+  <div class="column-one-quarter">
+    <h2 class="bold-medium">One quarter</h2>
+    <p>
+      This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+    </p>
+  </div>
+  <div class="column-one-quarter">
+    <h2 class="bold-medium">One quarter</h2>
+    <p>
+      This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+    </p>
+  </div>
+</div>
+```
+## Grid unit proportions
+
+### Full width
+
+```
+TODO: [Insert example from here](http://govuk-elements.herokuapp.com/layout/)
+```
+
+```html
+<div class="grid-row">
+  <div class="column-full">
+    <p>Content</p>
+  </div>
+</div>
+```
+
+### Halves
+
+```
+TODO: [Insert example from here](http://govuk-elements.herokuapp.com/layout/)
+```
+
+```html
+<div class="grid-row">
+  <div class="column-one-half">
+    <p>Content</p>
+  </div>
+  <div class="column-one-half">
+    <p>Content</p>
+  </div>
+</div>
+```
+
+### Thirds
+
+```
+TODO: [Insert example from here](http://govuk-elements.herokuapp.com/layout/)
+```
+
+```html 
+<div class="grid-row">
+  <div class="column-one-third">
+    <p>Content</p>
+  </div>
+  <div class="column-one-third">
+    <p>Content</p>
+  </div>
+  <div class="column-one-third">
+    <p>Content</p>
+  </div>
+</div>
+```
+
+### Two thirds / One third
+
+```
+TODO: [Insert example from here](http://govuk-elements.herokuapp.com/layout/)
+```
+
+```html
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <p>Content</p>
+  </div>
+  <div class="column-one-third">
+    <p>Content</p>
+  </div>
+</div>
+```
+
+### One third / Two thirds
+
+```
+TODO: [Insert example from here](http://govuk-elements.herokuapp.com/layout/)
+```
+
+```html
+<div class="grid-row">
+  <div class="column-one-third">
+    <p>Content</p>
+  </div>
+  <div class="column-two-thirds">
+    <p>Content</p>
+  </div>
+</div>
+```
+
+### Quarters
+
+```
+TODO: [Insert example from here](http://govuk-elements.herokuapp.com/layout/)
+```
+
+```html 
+<div class="grid-row">
+  <div class="column-one-quarter">
+    <p>Content</p>
+  </div>
+  <div class="column-one-quarter">
+    <p>Content</p>
+  </div>
+  <div class="column-one-quarter">
+    <p>Content</p>
+  </div>
+  <div class="column-one-quarter">
+    <p>Content</p>
+  </div>
+</div>
+```

--- a/app/docs/elements/01-layout/03-breakpoints.md
+++ b/app/docs/elements/01-layout/03-breakpoints.md
@@ -1,0 +1,4 @@
+---
+title: Media query breakpoints
+---
+

--- a/app/docs/elements/02-typography/01-index.md
+++ b/app/docs/elements/02-typography/01-index.md
@@ -1,0 +1,86 @@
+---
+title: Typography
+context:
+  lede: For GOV.UK domains, always use the GDS Transport Website font in Light and Bold.
+---
+
+{{ lede }}
+
+## Font
+
+Use the GDS Transport Website font in Light and Bold. It’s licensed for use on the GOV.UK domains only.
+
+For services publicly available on different domains, use an alternative typeface like Arial.
+
+## Typography
+
+```
+TODO: [Insert full page typography example from here](http://govuk-elements.herokuapp.com/typography/example-typography/)
+```
+
+```html
+<h1 class="heading-xlarge">
+  <span class="heading-secondary">Typography</span>
+  Example: Typography
+</h1>
+
+<h1 class="heading-xlarge">
+  <span class="heading-secondary">A 27px section heading</span>
+  A 48px heading
+</h1>
+
+<p class="lede">
+  This is an intro paragraph at 24px. Maecenas faucibus mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Curabitur blandit tempus porttitor. Vestibulum id ligula porta felis euismod semper.
+</p>
+
+<h2 class="heading-large">A 36px heading</h2>
+
+<p>
+  This is a body copy paragraph at 19px. Donec id elit non mi porta gravida at eget metus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec sed odio dui. Aenean lacinia bibendum nulla sed consectetur. Aenean lacinia bibendum nulla sed consectetur. Sed posuere consectetur est at lobortis.
+</p>
+
+<h3 class="heading-medium">A 24px heading</h3>
+
+<p>
+  Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum. Vestibulum id ligula porta felis euismod semper. Donec id elit non mi porta gravida at eget metus.
+</p>
+
+<h4 class="heading-small">A 19px heading</h4>
+
+<p>
+  Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.
+</p>
+
+<ul class="list list-bullet">
+  <li>here is a bulleted list</li>
+  <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
+  <li>vestibulum id ligula porta felis euismod semper</li>
+  <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
+</ul>
+
+<ol class="list list-number">
+  <li>here is a numbered list</li>
+  <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
+  <li>vestibulum id ligula porta felis euismod semper</li>
+  <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
+</ol>
+
+<ul class="list">
+  <li><a href="#">Related link</a></li>
+  <li><a href="#">Related link</a></li>
+  <li><a href="#">Related link</a></li>
+  <li><a href="#" class="bold-xsmall">More</a></li>
+</ul>
+
+<p>
+  Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.
+</p>
+
+<hr>
+
+<p>
+  Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.
+</p>
+```
+
+[next section: Headings](/docs/elements/typography/headings/)

--- a/app/docs/elements/02-typography/02-headings.md
+++ b/app/docs/elements/02-typography/02-headings.md
@@ -1,0 +1,23 @@
+---
+title: Headings
+---
+
+* use GDS Transport Website Bold
+* use sentence case for headings
+* use headings consistently to create a clear hierarchy
+
+```
+TODO: [Insert example from here](http://govuk-elements.herokuapp.com/typography/)
+```
+
+```html
+<h1 class="heading-xlarge">A 48px Bold heading</h1>
+
+<h2 class="heading-large">A 36px Bold heading</h2>
+
+<h3 class="heading-medium">A 24px Bold heading</h3>
+
+<h4 class="heading-small">A 19px Bold heading</h4>
+```
+
+[next section: Body copy](/docs/elements/typography/body-copy/)

--- a/app/docs/elements/02-typography/03-body-copy.md
+++ b/app/docs/elements/02-typography/03-body-copy.md
@@ -1,0 +1,44 @@
+---
+title: Body copy
+---
+
+## Lead paragraph
+
+* use 24px for a lead paragraph
+* there should only be one lead paragraph per page
+
+```
+TODO: [Insert example from here](http://govuk-elements.herokuapp.com/typography/)
+```
+
+```html
+<p class="lede">
+  A 24px lead paragraph, maecenas sed diam eget risus varius blandit sit amet non magna.
+</p>
+<p>
+  A 19px body copy paragraph, maecenas sed diam eget risus varius blandit sit amet non magna.
+</p>
+```
+
+## Body copy
+
+* use GDS Transport Website Light
+* avoid using bold and italics
+* use 19px for body copy – 16px for smaller screens
+* use smaller sizes only if there’s a user need (eg 16px, 14px, 12px)
+* make sure lines of text don’t exceed 75 characters, as they become harder to read beyond that point
+
+```
+TODO: [Insert example from here](http://govuk-elements.herokuapp.com/typography/)
+```
+
+```html
+<p>
+  A 19px body copy paragraph, maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla.
+</p>
+<p class="font-xsmall">
+  A 16px supporting text paragraph, maecenas sed diam eget risus varius blandit sit amet non magna. Donec ullamcorper nulla non metus auctor fringilla.
+</p>
+```
+
+[next section: Links](/docs/elements/typography/links/)

--- a/app/docs/elements/02-typography/04-links.md
+++ b/app/docs/elements/02-typography/04-links.md
@@ -1,0 +1,25 @@
+---
+title: Links
+---
+
+* links within body copy should be blue and underlined
+* links without surrounding text should not have a full stop at the end
+* link colours can be found in the colour palette
+
+```
+TODO: [Insert example from here](http://govuk-elements.herokuapp.com/typography/)
+```
+
+```html
+<p>
+  <a href="#">A 19px link without surrounding text</a>
+</p>
+
+<p>
+  <a href="#">A 19px body copy link</a>. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
+</p>
+
+<a href="#" class="link-back">Back</a>
+```
+
+[next section: Lists](/docs/elements/typography/lists/)

--- a/app/docs/elements/02-typography/05-lists.md
+++ b/app/docs/elements/02-typography/05-lists.md
@@ -1,0 +1,50 @@
+---
+title: Lists
+---
+
+List items start with a lowercase letter and have no full stop at the end.
+
+```
+TODO: [Insert example from here](http://govuk-elements.herokuapp.com/typography/)
+```
+
+```
+TODO: Insert default list component
+```
+
+```html
+<ul class="list">
+  <li><a href="#">Related link</a></li>
+  <li><a href="#">Related link</a></li>
+  <li><a href="#">Related link</a></li>
+  <li><a href="#" class="bold-xsmall">More</a></li>
+</ul>
+```
+
+```
+TODO: Insert --list-bullet component
+```
+
+```html
+<ul class="list list-bullet">
+  <li>here is a bulleted list</li>
+  <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
+  <li>vestibulum id ligula porta felis euismod semper</li>
+  <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
+</ul>
+```
+
+```
+TODO: Insert --list-number component
+```
+
+```html
+<ol class="list list-number">
+  <li>here is a numbered list</li>
+  <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
+  <li>vestibulum id ligula porta felis euismod semper</li>
+  <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
+</ol>
+```
+
+[next section: Forms](/docs/elements/forms/)

--- a/app/docs/elements/03-forms/01-index.md
+++ b/app/docs/elements/03-forms/01-index.md
@@ -1,0 +1,15 @@
+---
+title: Form elements
+context:
+  lede: Keep forms as simple as possible – only ask what’s needed to run your service.
+---
+
+## Optional and mandatory fields
+
+- only ask for the information you absolutely need
+- if you do ask for optional information, mark the labels of optional fields with ‘(optional)’
+- don’t mark mandatory fields with asterisks
+
+## Fieldsets and legends
+
+Use fieldsets to group related form controls. The first element inside a fieldset must be a legend element which describes the group.

--- a/app/docs/elements/03-forms/02-labels.md
+++ b/app/docs/elements/03-forms/02-labels.md
@@ -1,0 +1,34 @@
+---
+title: Labels
+---
+
+* all form fields should be given labels
+* don’t hide labels, unless the surrounding context makes them unnecessary
+* labels should be aligned above their fields
+* label text should be short, direct and in sentence case
+* avoid colons at the end of labels
+* labels should be associated with form fields using the for attribute
+
+```html
+<label class="form-label" for="full-name-f1">Full name</label>
+<input class="form-control" id="full-name-f1" type="text">
+```
+
+Hint text
+
+* don’t use placeholder text in form fields, as this will disappear once content is entered into the form field
+* use hint text for supporting contextual help, this will always be shown
+* hint text should sit above a form field
+* ensure hint text can be read correctly by screen readers
+
+```html
+<label class="form-label" for="ni-number">
+  National Insurance number
+  <span class="form-hint">
+    It's on your National Insurance card, benefit letter, payslip or P60.
+    <br>
+    For example, ‘QQ 12 34 56 C’.
+  </span>
+</label>
+<input class="form-control" id="ni-number" type="text">
+```

--- a/app/docs/elements/03-forms/03-form-fields.md
+++ b/app/docs/elements/03-forms/03-form-fields.md
@@ -1,0 +1,33 @@
+---
+title: Form fields
+---
+
+Make field widths proportional to the input they take.
+
+Ensure that users can enter the information they need at smaller screen sizes.
+
+Snap form fields to 100% width at smaller screen sizes.
+
+## Form focus states
+
+#FFBF47
+$focus-colour
+
+All elements use the yellow focus style as a highlight, as either a fill or 3px outline.
+
+Click on the label “Full name” or inside the form field to show the focus state.
+
+## Spacing between form elements
+
+```html
+<!-- Use .form-group to create spacing when wrapping label and input pairs -->
+<div class="form-group">
+  <label class="form-label" for="first-name-2">First name</label>
+  <input class="form-control" id="first-name-2" name="first-name-2" type="text">
+</div>
+<div class="form-group">
+  <label class="form-label" for="last-name-2">Last name</label>
+  <input class="form-control" id="last-name-2" name="last-name-2" type="text">
+</div>
+```
+

--- a/app/docs/elements/03-forms/04-file-upload.md
+++ b/app/docs/elements/03-forms/04-file-upload.md
@@ -1,0 +1,25 @@
+---
+title: File upload
+---
+
+A control that lets the user select a file.
+
+```html
+<div class="form-group">
+  <label class="form-label" for="file-input">
+    Upload a file
+  </label>
+  <input type="file" id="file-input">
+</div>
+```
+
+We recommend using a native input using type="file", rather than a custom implementation.
+
+This is so:
+* the control gains focus when tabbing through the page
+* the control functions using a keyboard
+* the control functions using assistive technology
+* the control functions when javascript is not available
+
+A custom implementation of this control would need to meet the criteria above.
+

--- a/app/docs/elements/03-forms/05-select-box.md
+++ b/app/docs/elements/03-forms/05-select-box.md
@@ -1,0 +1,16 @@
+---
+title: Select boxes
+---
+
+Avoid using select boxes (drop-down lists) - use radio buttons or checkboxes instead.
+
+```html
+<div class="form-group">
+  <label class="form-label" for="select-box">This is the label text</label>
+  <select class="form-control" id="select-box">
+    <option>GOV.UK elements option 1</option>
+    <option>GOV.UK elements option 2</option>
+    <option>GOV.UK elements option 3</option>
+  </select>
+</div>
+```

--- a/app/docs/elements/03-forms/06-radio-buttons.md
+++ b/app/docs/elements/03-forms/06-radio-buttons.md
@@ -1,0 +1,11 @@
+---
+title: Radio buttons
+---
+
+* use these to let users choose a single option from a list
+* for more than two options, radio buttons should be stacked
+* radio buttons with large hit areas are easier to select with a mouse or touch devices
+
+```
+[TODO: Add example from here](http://govuk-elements.herokuapp.com/form-elements/example-radios-checkboxes/)
+```

--- a/app/docs/elements/03-forms/07-checkboxes.md
+++ b/app/docs/elements/03-forms/07-checkboxes.md
@@ -1,0 +1,10 @@
+---
+title: Checkboxes
+---
+
+* use these to select either on/off toggles or multiple selections
+* make it clear with words when users can select one or multiple options
+
+```
+[TODO: Add example from here](http://govuk-elements.herokuapp.com/form-elements/example-radios-checkboxes/)
+```

--- a/app/docs/elements/04-buttons/index.md
+++ b/app/docs/elements/04-buttons/index.md
@@ -1,7 +1,8 @@
-
-# Buttons
-
-## Use buttons to move though a transaction, aim to use only one button per page.
+---
+title: Buttons
+context:
+  lede: Use buttons to move though a transaction, aim to use only one button per page.
+---
 
 ### Button text
 

--- a/app/docs/elements/05-tables/index.md
+++ b/app/docs/elements/05-tables/index.md
@@ -1,0 +1,12 @@
+Numeric tabular data
+
+* when comparing rows of numbers, align numbers to the right in table cells
+* use the GOV.UK frontend toolkit’s tabular numbers to allow numbers of the same width to be more easily compared
+
+[Example showing right aligment of table columns]
+
+Data in a table
+
+Not all content in tables should be right aligned.
+
+[Example showing left aligned tabular data]

--- a/app/docs/elements/06-banners/01-phase-banner.md
+++ b/app/docs/elements/06-banners/01-phase-banner.md
@@ -1,0 +1,5 @@
+# Phase Banner
+
+Copied from [GOV.UK Elements](http://govuk-elements.herokuapp.com/alpha-beta-banners/).
+
+You have to use an alpha banner if your thing is in alpha, and a beta banner if it’s in beta.


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

#### What does it do?
<!--- Describe your changes -->
This is very much a work in progress, but I'd like to get this merged ahead of @dsingleton's changes to the structure of the app. 

This PR adds folders to structure the documentation and begins to copy over content from GOV.UK elements. 

#### Screenshots (if appropriate):
![layout gov uk frontend alpha](https://cloud.githubusercontent.com/assets/417754/21353335/7e479ace-c6bd-11e6-984c-a4df307fe938.png)

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply: -->
- New feature (non-breaking change which adds functionality)
