### PR TITLE
Update the form radio group component to use newer style

### DIFF
--- a/app/assets/scss/components/_form-custom.scss
+++ b/app/assets/scss/components/_form-custom.scss
@@ -1,78 +1,142 @@
+// Large hit area
+// Radio buttons & checkboxes
+
+// By default, block labels stack vertically
 .gv-c-form-custom {
 
-  @include media(mobile) {
-    float: none;
-    clear: left;
-  }
-
   display: block;
-
+  float: none;
+  clear: left;
   position: relative;
 
-  background: $panel-colour;
-  border: 1px solid $panel-colour;
-  padding: (18px $gutter $gutter-half $gutter * 1.8);
+  padding: (8px $gutter-one-third 9px 50px);
+  margin-bottom: $gutter-one-third;
 
-  margin-bottom: 10px;
   cursor: pointer; // Encourage clicking on block labels
 
-  // States
-  // Using .selected here as this is set by selection-buttons.js
-  &.selected,
-  // Ideally we'd use a state class, e.g. .is-selected
-  &.is-selected {
-    background: $white;
-    border-color: $black;
-  }
+  // remove 300ms pause on mobile
+  -ms-touch-action: manipulation;
+  touch-action: manipulation;
 
-  // Using .focused here as this is set by selection-buttons.js
-  &.focused,
-  // Ideally we'd use a state class, e.g. .has-focus, or is-focused
-  &.is-focused {
-    outline: $width-focus-outline solid $focus-colour;
+  @include media(tablet) {
+    float: left;
+    padding-top: 7px;
+    padding-bottom: 7px;
+    // width: 25%; - Test : check that text within labels will wrap
   }
 
   // Absolutely position inputs within label, to allow text to wrap
   &__control {
     position: absolute;
-    top: 15px;
-    left: $gutter-half;
     cursor: pointer;
-    margin: 0;
-    width: 29px;
-    height: 29px;
+    left: 0;
+    top: 0;
+    width: 38px;
+    height: 38px;
 
-    @include ie(8) {
-      top: 12px;
+    // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there.
+    @if ($is-ie == false) or ($ie-version == 9) {
+      .js-enabled & {
+        margin: 0;
+        @include opacity(0);
+      }
     }
-
-    // Don't add an outline here
-    outline: 0 !important;
-
-    // Change border on hover
-    &:hover {
-      border-color: $black;
-    }
-
   }
 
-  // To stack horizontally, use .--inline, to sit block labels next to each other
-  // &--inline {
-  //   clear: none;
-  //   @include media (tablet) {
-  //     margin-bottom: 0;
-  //     margin-right: 10px;
-  //   }
-  // }
-  // TODO:
-  // Use these for custom radios and checkboxes
-  // &--radio {
-  // }
-  // &--checkbox {
-  // }
+  .js-enabled & {
+    &.selection-button-radio::before {
+      content: "";
+      border: 2px solid;
+      background: transparent;
+      width: 34px;
+      height: 34px;
+      position: absolute;
+      top: 0;
+      left: 0;
+      @include border-radius(50%);
+    }
 
+    &.selection-button-radio::after {
+      content: "";
+      border: 10px solid;
+      width: 0;
+      height: 0;
+      position: absolute;
+      top: 9px;
+      left: 9px;
+      @include border-radius(50%);
+      @include opacity(0);
+    }
+
+    &.selection-button-checkbox::before {
+      content: "";
+      border: 2px solid;
+      background: transparent;
+      width: 34px;
+      height: 34px;
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
+
+    &.selection-button-checkbox::after {
+      content: "";
+      border: solid;
+      border-width: 0 0 5px 5px;
+      background: transparent;
+      width: 17px;
+      height: 7px;
+      position: absolute;
+      top: 10px;
+      left: 8px;
+      -moz-transform: rotate(-45deg); // Firefox 15 compatibility
+      -o-transform: rotate(-45deg); // Opera 12.0 compatibility
+      -webkit-transform: rotate(-45deg); // Safari 8 compatibility
+      -ms-transform: rotate(-45deg); // IE9 compatibility
+      transform: rotate(-45deg);
+      @include opacity(0);
+    }
+
+    // Focused state
+    &.selection-button-radio,
+    &.selection-button-checkbox {
+      &.focused::before {
+        @include box-shadow(0 0 0 5px $focus-colour);
+      }
+      // IE8 focus outline should stay as a border around the entire label
+      // Lack of padding doesn’t matter as IE8 won’t resize the inputs.
+      @include ie-lte(8) {
+        &.focused {
+          outline: 3px solid $focus-colour;
+
+          input:focus {
+            outline: none;
+          }
+        }
+      }
+    }
+
+    // Selected state
+    &.selection-button-radio,
+    &.selection-button-checkbox {
+      &.selected::after {
+        @include opacity(1);
+      }
+    }
+  }
+
+  &:last-child,
+  &:last-of-type {
+    margin-bottom: 0;
+  }
 }
 
-.gv-c-form-custom:last-child {
-  margin-bottom: 0;
+// To stack horizontally, use .inline on parent, to sit block labels next to each other
+.inline .block-label {
+  clear: none;
+
+  @include media (tablet) {
+    margin-bottom: 0;
+    margin-right: $gutter;
+  }
 }

--- a/app/assets/scss/components/_form-group.scss
+++ b/app/assets/scss/components/_form-group.scss
@@ -63,9 +63,9 @@
   @include core-19;
   width: 100%;
 
-  padding: 4px;
-  background-color: $white;
-  border: 2px solid $grey-1;
+  padding: 5px 4px 4px;
+  background-color: transparent;
+  border: 2px solid;
 }
 
 .gv-c-form-group__control--has-error {

--- a/app/components/_preview.nunj
+++ b/app/components/_preview.nunj
@@ -23,4 +23,10 @@
 <script src="{{ '/javascripts/govuk-template.min.js' | path }}"></script>
 <script src="{{ '/javascripts/toolkit.min.js' | path }}"></script>
 <script src="{{ '/javascripts/elements.min.js' | path }}"></script>
+<!-- TODO: Fix how this works, for now, initialise component js by updating initScript in the component's config file -->
+{% if _target.context.initScript %}
+  <script>
+    {{ _target.context.initScript }}
+  </script>
+{% endif %}
 </html>

--- a/app/components/_preview.nunj
+++ b/app/components/_preview.nunj
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-frontend.css' | path }}">
+    <link rel="shortcut icon" href="{{ '/images/template/favicon.ico' | path }}" type="image/ico">
     <title>Preview Layout</title>
     <script>
     // govuk_template sets js-enabled

--- a/app/components/_preview.nunj
+++ b/app/components/_preview.nunj
@@ -17,7 +17,15 @@
   </style>
 </head>
 <body>
+  {% if _target.context.openWrapper %}
+    {{ _target.context.openWrapper }}
+  {% endif %}
+
   {{ yield }}
+
+  {% if _target.context.closeWrapper %}
+    {{ _target.context.closeWrapper }}
+  {% endif %}
 </body>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 <script src="{{ '/javascripts/govuk-template.min.js' | path }}"></script>

--- a/app/components/_preview.nunj
+++ b/app/components/_preview.nunj
@@ -13,6 +13,7 @@
 <body>
   {{ yield }}
 </body>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 <script src="{{ '/javascripts/govuk-template.min.js' | path }}"></script>
 <script src="{{ '/javascripts/toolkit.min.js' | path }}"></script>
 <script src="{{ '/javascripts/elements.min.js' | path }}"></script>

--- a/app/components/_preview.nunj
+++ b/app/components/_preview.nunj
@@ -1,9 +1,14 @@
 <!DOCTYPE html>
-<html>
+<html class="no-js">
 <head>
     <meta charset="utf-8">
     <link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-frontend.css' | path }}">
     <title>Preview Layout</title>
+    <script>
+    // govuk_template sets js-enabled
+    // we're not loading the template as a wrapper for components, so this class must be set in the preview template
+    document.documentElement.className = document.documentElement.className.replace('no-js', 'js-enabled');
+    </script>
     <style>
       html {
         background-color: white;

--- a/app/components/_preview.nunj
+++ b/app/components/_preview.nunj
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
 <html class="no-js">
 <head>
-    <meta charset="utf-8">
-    <link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-frontend.css' | path }}">
-    <link rel="shortcut icon" href="{{ '/images/template/favicon.ico' | path }}" type="image/ico">
-    <title>Preview Layout</title>
-    <script>
-    // govuk_template sets js-enabled
-    // we're not loading the template as a wrapper for components, so this class must be set in the preview template
-    document.documentElement.className = document.documentElement.className.replace('no-js', 'js-enabled');
-    </script>
-    <style>
-      html {
-        background-color: white;
-      }
-    </style>
+  <meta charset="utf-8">
+  <link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-frontend.css' | path }}">
+  <link rel="shortcut icon" href="{{ '/images/template/favicon.ico' | path }}" type="image/ico">
+  <title>Preview Layout</title>
+  <script>
+  // govuk_template sets js-enabled
+  // we're not loading the template as a wrapper for components, so this class must be set in the preview template
+  document.documentElement.className = document.documentElement.className.replace('no-js', 'js-enabled');
+  </script>
+  <style>
+    html {
+      background-color: white;
+    }
+  </style>
 </head>
 <body>
   {{ yield }}

--- a/app/components/_preview.nunj
+++ b/app/components/_preview.nunj
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-frontend.css' | path }}">
   <link rel="shortcut icon" href="{{ '/images/template/favicon.ico' | path }}" type="image/ico">
-  <title>Preview Layout</title>
+  <title>{{ _target.title }} &#9670; GOV.UK Frontend Alpha</title>
   <script>
   // govuk_template sets js-enabled
   // we're not loading the template as a wrapper for components, so this class must be set in the preview template

--- a/app/components/_preview.nunj
+++ b/app/components/_preview.nunj
@@ -17,14 +17,19 @@
   </style>
 </head>
 <body>
-  {% if _target.context.openWrapper %}
-    {{ _target.context.openWrapper }}
+  {% if _target.context.setup.openWrapper %}
+    {{ _target.context.setup.openWrapper }}
   {% endif %}
 
   {{ yield }}
 
-  {% if _target.context.closeWrapper %}
-    {{ _target.context.closeWrapper }}
+  {{ _target.title }}
+  {{ _target.status }}
+  {{ _target.context.id }}
+  {{ _target.context.setup }}
+
+  {% if _target.context.setup.closeWrapper %}
+    {{ _target.context.setup.closeWrapper }}
   {% endif %}
 </body>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
@@ -32,9 +37,9 @@
 <script src="{{ '/javascripts/toolkit.min.js' | path }}"></script>
 <script src="{{ '/javascripts/elements.min.js' | path }}"></script>
 <!-- TODO: Fix how this works, for now, initialise component js by updating initScript in the component's config file -->
-{% if _target.context.initScript %}
+{% if _target.context.setup.initScript %}
   <script>
-    {{ _target.context.initScript }}
+    {{ _target.context.setup.initScript }}
   </script>
 {% endif %}
 </html>

--- a/app/components/form-radio-group/form-radio-group.config.js
+++ b/app/components/form-radio-group/form-radio-group.config.js
@@ -3,6 +3,8 @@ module.exports = {
   status: 'wip',
   context: {
     initScript: 'var $blockLabels = $(".gv-c-form-custom input[type=\'radio\'], .gv-c-form-custom input[type=\'checkbox\']"); new GOVUK.SelectionButtons($blockLabels);',
+    openWrapper: '<form>',
+    closeWrapper: '</form>',
     id: 'contact',
     name: 'contact-group',
     legend: 'How do you want to be contacted?',

--- a/app/components/form-radio-group/form-radio-group.config.js
+++ b/app/components/form-radio-group/form-radio-group.config.js
@@ -2,6 +2,7 @@ module.exports = {
   title: 'Form radio group',
   status: 'wip',
   context: {
+    initScript: 'var $blockLabels = $(".gv-c-form-custom input[type=\'radio\'], .gv-c-form-custom input[type=\'checkbox\']"); new GOVUK.SelectionButtons($blockLabels);',
     id: 'contact',
     name: 'contact-group',
     legend: 'How do you want to be contacted?',

--- a/app/components/form-radio-group/form-radio-group.config.js
+++ b/app/components/form-radio-group/form-radio-group.config.js
@@ -2,9 +2,11 @@ module.exports = {
   title: 'Form radio group',
   status: 'wip',
   context: {
-    initScript: 'var $blockLabels = $(".gv-c-form-custom input[type=\'radio\'], .gv-c-form-custom input[type=\'checkbox\']"); new GOVUK.SelectionButtons($blockLabels);',
-    openWrapper: '<form>',
-    closeWrapper: '</form>',
+    setup: {
+      initScript: 'var $blockLabels = $(".gv-c-form-custom input[type=\'radio\'], .gv-c-form-custom input[type=\'checkbox\']"); new GOVUK.SelectionButtons($blockLabels);',
+      openWrapper: '<form>',
+      closeWrapper: '</form>'
+    },
     id: 'contact',
     name: 'contact-group',
     legend: 'How do you want to be contacted?',

--- a/app/components/form-radio-group/form-radio-group.nunj
+++ b/app/components/form-radio-group/form-radio-group.nunj
@@ -12,7 +12,7 @@
     </legend>
 
     {% for radio in radioGroup %}
-      <label class="gv-c-form-custom" for="{{radio.id}}">
+      <label class="gv-c-form-custom selection-button-radio" for="{{radio.id}}">
         <input class="gv-c-form-custom__control"
                id="{{radio.id}}"
                type="radio"

--- a/test/specs/components/form_radio_group_spec.js
+++ b/test/specs/components/form_radio_group_spec.js
@@ -31,13 +31,13 @@ describe('Form radio group component', () => {
           <legend>
             <span class="gv-c-form-group__label">How do you want to be contacted?</span>
           </legend>
-          <label class="gv-c-form-custom" for="example-contact-by-email">
+          <label class="gv-c-form-custom selection-button-radio" for="example-contact-by-email">
             <input class="gv-c-form-custom__control" id="example-contact-by-email"
             type="radio" name="contact" value="contact-by-email">Email</label>
-          <label class="gv-c-form-custom" for="example-contact-by-phone">
+          <label class="gv-c-form-custom selection-button-radio" for="example-contact-by-phone">
             <input class="gv-c-form-custom__control" id="example-contact-by-phone"
             type="radio" name="contact" value="contact-by-phone">Phone</label>
-          <label class="gv-c-form-custom" for="example-contact-by-text">
+          <label class="gv-c-form-custom selection-button-radio" for="example-contact-by-text">
             <input class="gv-c-form-custom__control" id="example-contact-by-text"
             type="radio" name="contact" value="contact-by-text">Text</label>
         </fieldset>


### PR DESCRIPTION
#### What does it do?

This PR updates the styles for the form-radio-group component. 

I've tried to add as much detail as possible in the commit history as to why I'm making these changes. 

*selection-buttons.js requires parent form element*
If it doesn't exist, the `selected` class isn't removed when a new radio button is clicked.
I've added two properties to the config, `openWrapper` and `closeWrapper` to set the parent opening and closing elements.

*selection-buttons.js requires jQuery* 
I've included Google-hosted jQuery, this is so we don't have to copy jQuery into the app. 

*a js-enabled class must be applied to the preview layout*
The styles for the custom radio buttons and checkboxes are only applied if javascript is available. This means that js-enabled must be set in the preview layout, this functionality was previously set by govuk_template. It would be nice to use `has-` instead for state-based classes, we can do this later.

*components don't yet initialize themselves*
For now, an extra property has been defined in the config file for a component `initScript` to allow configuration on a per-component basis.

#### Screenshots (if appropriate):

Old radio buttons:

![before - form radio group default gov uk frontend alpha](https://cloud.githubusercontent.com/assets/417754/21356238/c75d18c8-c6c8-11e6-93c9-bf0863053dd0.png)

New radio buttons:

![after - form radio group default gov uk frontend alpha](https://cloud.githubusercontent.com/assets/417754/21356239/cadd22ae-c6c8-11e6-9b50-ff37b26c2f70.png)


#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply: -->
- New feature (non-breaking change which adds functionality)
