### PR TITLE
Stop fractal instance appearing in search

### DIFF
--- a/lib/fractal/govuk-theme/views/layouts/skeleton.nunj
+++ b/lib/fractal/govuk-theme/views/layouts/skeleton.nunj
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
   <script>
   window.frctl = {
       env: '{% if frctl.env.server %}server{% else %}static{% endif %}'


### PR DESCRIPTION
#### What does it do?
Prevents fractal showing up in search engine results

- New feature (non-breaking change which adds functionality)

While in alpha (and probably beta) we don't want the style
guide to be easily found/confused for a production
thing. 