### PR TITLE
Add a 'this is an alpha' warning to the fractal theme

### DIFF
--- a/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
+++ b/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
@@ -213,3 +213,12 @@ a:active {
 
 }
 
+.alpha-warning {
+  padding: 10px 30px;
+  background-color: #f6f6f6;
+  border-bottom: 1px solid rgba(83, 83, 99, 0.25);
+  
+  .phase-banner {
+    margin-right: 5px;
+  }
+}

--- a/lib/fractal/govuk-theme/assets/scss/tech-docs-template/modules/_phase-banner.scss
+++ b/lib/fractal/govuk-theme/assets/scss/tech-docs-template/modules/_phase-banner.scss
@@ -5,5 +5,6 @@
   letter-spacing: 1px;
   @include screen {
     background: #005EA5;
+    color: #fff;
   }
 }

--- a/lib/fractal/govuk-theme/views/partials/header.nunj
+++ b/lib/fractal/govuk-theme/views/partials/header.nunj
@@ -10,9 +10,13 @@
         </span>
         <span class="header__title">
           Frontend
-          <span class="phase-banner">ALPHA</span>
         </span>
       </a>
     </div>
   </div>
 </header>
+
+<div class="alpha-warning">
+  <span class="phase-banner">ALPHA</span>
+  This tool is a prototype and not intended for use on production services. <a href="https://github.com/alphagov/govuk_frontend_alpha">Find out more and give feedback</a>
+</div>


### PR DESCRIPTION
While in Alpha we want to share what we've built so far, including
a version of the Fractal output, but we don't want it to be
confused for anything a service team should be following.

Make clear it's a prototype, and not for production use, and allow
folks to learn more about the alpha and give us feedback.

The CSS to style it was quite quick and dirty, but will be thrown
away at some point, so i'm not too bothered.


![image](https://cloud.githubusercontent.com/assets/63201/21458116/d79d11f6-c92b-11e6-9df3-f0d6f2a80c3d.png)
