### PR TITLE
Short term fix for the static build of Fractal

### DIFF
--- a/config/paths.json
+++ b/config/paths.json
@@ -19,6 +19,7 @@
   "fractal": "lib/fractal",
   "fractalThemeCss": "lib/fractal/govuk-theme/assets/css/",
   "fractalThemeScss": "lib/fractal/govuk-theme/assets/scss/",
+  "fractalThemeImages": "lib/fractal/govuk-theme/assets/images/",
   "fractalThemeViews": "lib/fractal/govuk-theme/views/",
   "gem": "dist/gem/",
   "gemLib": "dist/gem/lib",

--- a/lib/tasks/fractal-build.js
+++ b/lib/tasks/fractal-build.js
@@ -5,6 +5,7 @@ const gulp = require('gulp')
 const fractal = require('../../lib/fractal/config/fractal.js')
 // keep a reference to the fractal CLI console utility
 const logger = fractal.cli.console
+const paths = require('../../config/paths')
 
 /*
  * Run a static export of the project web UI.
@@ -16,11 +17,26 @@ const logger = fractal.cli.console
  * configuration option set above.
  */
 
-gulp.task('fractal:build', function () {
+gulp.task('fractal:build', ['fractal:assets'], function () {
   const builder = fractal.web.builder()
   builder.on('progress', (completed, total) => logger.update(`Exported ${completed} of ${total} items`, 'info'))
   builder.on('error', err => logger.error(err.message))
+
   return builder.build().then(() => {
     logger.success('Fractal build completed!')
+
+    // Fix theme assets not being copied, see below
+    copyThemeAssets()
   })
 })
+
+/*
+ * Copy the theme assets to the static build location
+ *
+ * Fractal should do this, but it looks like a bug. Mentioned to
+ * the fractal team and they're going to look into it.
+ */
+const copyThemeAssets = () => {
+  gulp.src(paths.fractalThemeCss + '*.css').pipe(gulp.dest(paths.distFractal + 'theme/css'))
+  gulp.src(paths.fractalThemeImages + '*').pipe(gulp.dest(paths.distFractal + 'theme/images'))
+}


### PR DESCRIPTION
#### What does it do?

Manually copy our theme CSS and Images into the appropriate dirs to make
the static build of Fractal work, previously it was missing out theme assets.

I spoke to the Fractal team and they think this should happen automatically,
which makes sense for theme assets to be auto-copied. In the mean time
this allows us to use static builds if we want to.

Also ensures that the fractal theme assets have been compiled from source
before running the static build. This would've only worked if the fractal
server had run and the compiled assets happened to be there.

Note: The static build only work if the static output is served from `/`, not
directly from file system, or hosted subdir. But would be fine on Heroku/GH Pages

#### What type of change is it?
- New feature (non-breaking change which adds functionality)
