### PR TITLE
Test fixes and refactor

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -11,6 +11,24 @@ glob.sync(path.join(paths.srcComponents, configPattern)).forEach(file => {
   components[name] = require(path.relative(__dirname, file))
 })
 
+const get = name => components[name]
+
+const getVariantsFor = name => {
+  const component = get(name)
+  let variants = []
+  if (component.context) {
+    variants.push({
+      name: name,
+      context: component.context
+    })
+  }
+  if (component.variants) {
+    variants = variants.concat(component.variants)
+  }
+  return variants
+}
+
 module.exports.all = components
-module.exports.get = name => components[name]
+module.exports.get = get
 module.exports.templatePathFor = name => path.join(paths.srcComponents, name, `${name}.nunj`)
+module.exports.getVariantsFor = getVariantsFor

--- a/src/components/phase-banner/phase-banner.config.js
+++ b/src/components/phase-banner/phase-banner.config.js
@@ -22,5 +22,5 @@ module.exports = {
       messageHtml: 'This service is new – your <a href="#">feedback</a> will help us to improve it.'
     }
   }],
-  arguments: ['phase', 'message']
+  arguments: ['phase', 'message', 'messageHtml']
 }

--- a/test/specs/components/smoke_spec.js
+++ b/test/specs/components/smoke_spec.js
@@ -12,10 +12,10 @@ const expectComponentRenders = (name, input) => {
 describe('All components variants render without errrors', () => {
   Object.keys(components.all).map(name => {
     describe(`${name}`, () => {
-      let component = components.get(name)
-      let variants = [{name: 'defaut', context: component.context}].concat(component.variants)
+      let variants = components.getVariantsFor(name)
       for (let variant of variants) {
         it(`${variant.name}`, () => {
+          console.log(variant.context)
           expectComponentRenders(name, variant.context)
         })
       }

--- a/test/specs/components/smoke_spec.js
+++ b/test/specs/components/smoke_spec.js
@@ -13,9 +13,9 @@ describe('Components render examples without errors', () => {
   Object.keys(components.all).map(name => {
     it(`${name} component renders all variants without errors`, () => {
       let component = components.get(name)
-      let variants = [component.context].concat(component.variants)
+      let variants = [{context: component.context}].concat(component.variants)
       for (let variant of variants) {
-        expectComponentRenders(name, variant)
+        expectComponentRenders(name, variant.context)
       }
     })
   })

--- a/test/specs/components/smoke_spec.js
+++ b/test/specs/components/smoke_spec.js
@@ -9,13 +9,15 @@ const expectComponentRenders = (name, input) => {
   }).to.not.throw()
 }
 
-describe('Components render examples without errors', () => {
+describe('All components variants render without errrors', () => {
   Object.keys(components.all).map(name => {
-    it(`${name} component renders all variants without errors`, () => {
+    describe(`${name}`, () => {
       let component = components.get(name)
-      let variants = [{context: component.context}].concat(component.variants)
+      let variants = [{name: 'defaut', context: component.context}].concat(component.variants)
       for (let variant of variants) {
-        expectComponentRenders(name, variant.context)
+        it(`${variant.name}`, () => {
+          expectComponentRenders(name, variant.context)
+        })
       }
     })
   })

--- a/test/specs/transpiler_spec.js
+++ b/test/specs/transpiler_spec.js
@@ -151,4 +151,29 @@ describe('Transpilation', () => {
       })
     })
   })
+
+  describe('Components arguments are defined', () => {
+    Object.keys(components.all).map(name => {
+      it(`${name}`, () => {
+        const component = components.get(name)
+        const variants = components.getVariantsFor(name)
+
+        const expectedArgs = component.arguments
+        // We're using `setup` to hack around leaky components, it shouldn't
+        // exist long term, if it does clearly mark it as magic, eg `__setup`
+        const allExpectedArgs = expectedArgs.concat(['setup'])
+
+        // Extract array of context keys (arguments) for each variant
+        let allVariantArgs = variants.map(v => Object.keys(v.context))
+        // Flattern arrays of argument names (@TODO use underscore `flatten`)
+        allVariantArgs = [].concat.apply([], allVariantArgs)
+        // Cast to a Set to get unique arg names, and back to array
+        allVariantArgs = [...new Set(allVariantArgs)]
+        // for (let variant of variants) {
+        for (let variantArg of allVariantArgs) {
+          expect(variantArg).to.be.oneOf(allExpectedArgs, 'Missing argument definition')
+        }
+      })
+    })
+  })
 })

--- a/test/specs/transpiler_spec.js
+++ b/test/specs/transpiler_spec.js
@@ -132,18 +132,22 @@ describe('Transpilation', () => {
     const allComponents = components.all
 
     Object.keys(allComponents).map(name => {
-      const component = allComponents[name]
+      const component = components.get(name)
       const sourcePath = components.templatePathFor(name)
-      const expected = nunjucks.render(sourcePath, component.context)
+      const variants = components.getVariantsFor(name)
 
-      describe('into Nunjucks', () => {
-        it(`${name} should have the same output after transpile`, function () {
-          let transpiledTemplate = transpiler.transpileComponentSync('nunjucks', name, fs.readFileSync(sourcePath).toString())
-          let invocation = `{{ ${changeCase.camelCase(name)}(${component.arguments.join(', ')}) }}`
-          let output = nunjucks.renderString(transpiledTemplate + invocation, component.context)
-          // Trim leading/trailing whistespace, macro def results in new lines
-          expect(output.trim()).to.equal(expected.trim())
-        })
+      describe(`${component.title} into Nunjucks`, () => {
+        for (let variant of variants) {
+          let expected = nunjucks.render(sourcePath, variant.context)
+
+          it(`${name}:${variant.name} should have the same output after transpile`, function () {
+            let transpiledTemplate = transpiler.transpileComponentSync('nunjucks', name, fs.readFileSync(sourcePath).toString())
+            let invocation = `{{ ${changeCase.camelCase(name)}(${component.arguments.join(', ')}) }}`
+            let output = nunjucks.renderString(transpiledTemplate + invocation, variant.context)
+            // Trim leading/trailing whistespace, macro def results in new lines
+            expect(output.trim()).to.equal(expected.trim())
+          })
+        }
       })
     })
   })


### PR DESCRIPTION
This is a collection of bug fixes for component and transpiring tests, increasing the coverage and confidence.

#### What does it do?
Best read commit by commit, but generally:

- Ensure the default (if it exists) and each variant is tested in component smoke tests, and in transpiler smoke tests
- Ensure all arguments in variants are defined in component configuration, to avoid silent bugs where transpiled versions will be missing those arguments.
- Improve readability of test output.

#### Considerations

This is Good Enough for alpha confidence, but for a beta we'll need to re-think the testing approach somewhat. In particular how directly reading the config variants differs from how `fractal` treats variants (eg, it's inheritance setup). Do we tie into the fractal lib code to get their version of component variants expanded/inherited? Will the public API allow that? Does that tie us to fractal too much? If we don't, then we shouldn't rely on the fractal inheritance approach for variants, are we OK with that, will it cause duplication, or confusion for contributors?

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)
