### PR TITLE
Move component specs into their component folders

### DIFF
--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -12,7 +12,10 @@ gulp.task('test:lib', () => gulp.src(paths.testSpecs + 'transpiler_spec.js', {re
   .pipe(mocha({reporter: 'spec'}))
 )
 
-gulp.task('test:components', () => gulp.src(paths.testSpecs + 'components' + '**/*', {read: false})
+gulp.task('test:components', () => gulp.src([
+  paths.testSpecs + 'components/' + '**/*',
+  paths.srcComponents + '**/*.spec.js'
+], {read: false})
   .pipe(mocha({reporter: 'spec'}))
 )
 

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -1,4 +1,4 @@
-const expectComponent = require('./helper').expectComponent
+const expectComponent = require('../../../test/specs/components/helper').expectComponent
 
 describe('Button component', () => {
   it('should render', () => {

--- a/src/components/form-group/form-group.spec.js
+++ b/src/components/form-group/form-group.spec.js
@@ -1,4 +1,4 @@
-const expectComponent = require('./helper').expectComponent
+const expectComponent = require('../../../test/specs/components/helper').expectComponent
 
 describe('Form group component', () => {
   it('should render', () => {

--- a/src/components/form-radio-group/form-radio-group.spec.js
+++ b/src/components/form-radio-group/form-radio-group.spec.js
@@ -1,4 +1,4 @@
-const expectComponent = require('./helper').expectComponent
+const expectComponent = require('../../../test/specs/components/helper').expectComponent
 
 describe('Form radio group component', () => {
   it('should render', () => {

--- a/src/components/phase-banner/phase-banner.spec.js
+++ b/src/components/phase-banner/phase-banner.spec.js
@@ -1,4 +1,4 @@
-const expectComponent = require('./helper').expectComponent
+const expectComponent = require('../../../test/specs/components/helper').expectComponent
 
 describe('Phase banner component', () => {
   it('should render', () => {


### PR DESCRIPTION
This moves the individual component specs to live with their application code. The specs have also been renamed to better match the component conventions.