### PR TITLE
Standardise template name conventions in dist versions

### DIFF
--- a/lib/tasks/build-components.js
+++ b/lib/tasks/build-components.js
@@ -12,8 +12,6 @@ let transpileRunner = templateLanguage => {
   // Templates starting with underscores are ignored
   return gulp.src(paths.srcComponents + '[^_]*/[^_]*.njk')
     .pipe(transpiler.transpileComponent(templateLanguage, packageJson.version))
-    // no .html prefix like build:template, components have different naming convention
-    // @FIXME: standardise the naming convention in source
     // `dirname` drops the extra level of dir, `button/button.ext` => `button.ext`
     .pipe(rename({dirname: '', extname: '.' + templateLanguage}))
     .pipe(gulp.dest(paths.bundleComponents))

--- a/lib/tasks/build-components.js
+++ b/lib/tasks/build-components.js
@@ -13,7 +13,7 @@ let transpileRunner = templateLanguage => {
   return gulp.src(paths.srcComponents + '[^_]*/[^_]*.njk')
     .pipe(transpiler.transpileComponent(templateLanguage, packageJson.version))
     // `dirname` drops the extra level of dir, `button/button.ext` => `button.ext`
-    .pipe(rename({dirname: '', extname: '.' + templateLanguage}))
+    .pipe(rename({dirname: '', extname: '.' + transpiler.extensionForTarget(templateLanguage)}))
     .pipe(gulp.dest(paths.bundleComponents))
 }
 

--- a/lib/tasks/build-templates.js
+++ b/lib/tasks/build-templates.js
@@ -11,7 +11,7 @@ const transpiler = require('../transpilation/transpiler.js')
 let transpileRunner = templateLanguage => {
   return gulp.src(paths.templates + '*.njk')
     .pipe(transpiler.transpileTemplate(templateLanguage, packageJson.version))
-    .pipe(rename({extname: '.' + templateLanguage}))
+    .pipe(rename({extname: '.' + transpiler.extensionForTarget(templateLanguage)}))
     .pipe(gulp.dest(paths.bundleTemplates))
 }
 

--- a/lib/tasks/build-templates.js
+++ b/lib/tasks/build-templates.js
@@ -11,7 +11,7 @@ const transpiler = require('../transpilation/transpiler.js')
 let transpileRunner = templateLanguage => {
   return gulp.src(paths.templates + '*.njk')
     .pipe(transpiler.transpileTemplate(templateLanguage, packageJson.version))
-    .pipe(rename({extname: '.html.' + templateLanguage}))
+    .pipe(rename({extname: '.' + templateLanguage}))
     .pipe(gulp.dest(paths.bundleTemplates))
 }
 

--- a/lib/transpilation/handlebars_transpiler.js
+++ b/lib/transpilation/handlebars_transpiler.js
@@ -10,3 +10,4 @@ const textFor = (key, defaultContent = '') => blockFor(key, defaultContent)
 module.exports.assetPath = assetPath
 module.exports.blockFor = blockFor
 module.exports.textFor = textFor
+module.exports.fileExt = 'hbs'

--- a/lib/transpilation/nunjucks_transpiler.js
+++ b/lib/transpilation/nunjucks_transpiler.js
@@ -20,3 +20,4 @@ const componentArgs = (fileContents, name, args) => {
 
 module.exports.assetPath = assetPath
 module.exports.componentArgs = componentArgs
+module.exports.fileExt = 'njk'

--- a/lib/transpilation/transpiler.js
+++ b/lib/transpilation/transpiler.js
@@ -70,6 +70,12 @@ const transpileComponentSync = (target, componentName, componentTemplate) => {
   return transpiledTemplate
 }
 
+const extensionForTarget = target => {
+  const targetTranspiler = require(`./${target}_transpiler.js`)
+  return targetTranspiler.fileExt || target
+}
+
 module.exports.transpileTemplate = transpileTemplate
 module.exports.transpileComponent = transpileComponent
 module.exports.transpileComponentSync = transpileComponentSync
+module.exports.extensionForTarget = extensionForTarget


### PR DESCRIPTION
- https://github.com/alphagov/govuk_frontend_alpha/commit/328201494ca01c76d5b4c86e316a04b8ba19d5ec Standardise the naming convention between templates and components
- https://github.com/alphagov/govuk_frontend_alpha/commit/497d57b92bd8ae8f7b363d16b3ccf1eb3f686d10 Use `njk` for dist templates, as for source (and use`hbs` for handlebars, which seems to be the convention

#### What type of change is it?
- Breaking change (fix or feature that would cause existing functionality to change)

The template and component paths will have changed, consumers will need to update some paths.
