### PR TITLE
Distribute nunjucks components in single file of macros

### DIFF
--- a/lib/tasks/package-npm.js
+++ b/lib/tasks/package-npm.js
@@ -7,6 +7,7 @@ const packageName = require('../../gulpfile.js').packageName
 const gulp = require('gulp')
 const runSequence = require('run-sequence')
 const run = require('gulp-run')
+const concat = require('gulp-concat')
 const del = require('del')
 const fs = require('fs')
 
@@ -33,7 +34,7 @@ gulp.task('package:npm:prepare', () => {
   gulp.src(paths.bundleScss + '**/*').pipe(gulp.dest(paths.npmScss))
   gulp.src(paths.bundleJs + '**/*').pipe(gulp.dest(paths.npmJs))
   gulp.src(paths.bundleTemplates + '**/*').pipe(gulp.dest(paths.npmTemplates))
-  gulp.src(paths.bundleComponents + '**/*').pipe(gulp.dest(paths.npmComponents))
+  gulp.src(paths.bundleComponents + '**/*.njk').pipe(concat('components.njk')).pipe(gulp.dest(paths.npmComponents))
   return gulp.src('./package.json').pipe(gulp.dest(paths.npm))
 })
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "event-stream": "^3.3.4",
     "express": "^4.14.0",
     "gulp": "^3.9.1",
+    "gulp-concat": "^2.6.1",
     "gulp-cssnano": "^2.1.2",
     "gulp-jasmine-browser": "^1.7.0",
     "gulp-mocha": "^3.0.1",


### PR DESCRIPTION
This feels like a nicer model for consuming apps, theres an example of
how it works on the node consumer app:

https://github.com/alphagov/govuk_frontend_alpha_npm_test/pull/10

This works from a consuming app point of view, but's this is tied to
the `npm` build, rather than the nunjucks format. We're not super
clear on the distinction bewteen the two at the moment

#### What type of change is it?
- Breaking change (fix or feature that would cause existing functionality to change)


