### PR TITLE
Add missing watch tasks for theme assets

### DIFF
--- a/config/paths.json
+++ b/config/paths.json
@@ -19,6 +19,7 @@
   "fractal": "lib/fractal",
   "fractalThemeCss": "lib/fractal/govuk-theme/assets/css/",
   "fractalThemeScss": "lib/fractal/govuk-theme/assets/scss/",
+  "fractalThemeImages": "lib/fractal/govuk-theme/assets/images/",
   "fractalThemeViews": "lib/fractal/govuk-theme/views/",
   "gem": "dist/gem/",
   "gemLib": "dist/gem/lib",

--- a/config/paths.json
+++ b/config/paths.json
@@ -19,6 +19,7 @@
   "fractal": "lib/fractal",
   "fractalThemeCss": "lib/fractal/govuk-theme/assets/css/",
   "fractalThemeScss": "lib/fractal/govuk-theme/assets/scss/",
+  "fractalThemeJs": "lib/fractal/govuk-theme/assets/js/",
   "fractalThemeImages": "lib/fractal/govuk-theme/assets/images/",
   "fractalThemeViews": "lib/fractal/govuk-theme/views/",
   "gem": "dist/gem/",

--- a/lib/tasks/fractal-assets.js
+++ b/lib/tasks/fractal-assets.js
@@ -7,29 +7,45 @@ const sass = require('gulp-sass')
 
 // This file provides the build tasks for the Fractal theme assets
 // To keep the "theme" assets separate, static assets can be found in /fractal/govuk-theme/
-// At present only the Sass is compiled to css, later tasks for scripts and image can be added.
 
 gulp.task('fractal:assets', [
-  'fractal:assets:styles'
-  // TODO: 'fractal:theme:scripts',
-  // TODO: 'fractal:theme:images'
+  'fractal:assets:styles',
+  'fractal:assets:scripts',
+  'fractal:assets:images'
 ])
+
+/*
+ * Copy the theme assets to the static build location
+ *
+ * Fractal should do this, but it looks like a bug. Mentioned to
+ * the fractal team and they're going to look into it.
+ *
+ * Once fixed [1] and [2] can be removed.
+ */
 
 // Styles - compile SCSS
 gulp.task('fractal:assets:styles', () => {
   console.log('theme styles compiled')
   return gulp.src(paths.fractalThemeScss + '**/**/*.scss')
-   .pipe(sass({
-     outputStyle: 'expanded',
-     includePaths: [paths.fractalThemeScss + 'tech-docs-template']
-   }).on('error', sass.logError))
-  .pipe(gulp.dest(paths.fractalThemeCss))
-  // Copy the theme assets to the static build location
-  .pipe(gulp.dest(paths.distFractal + 'theme/css'))
+    .pipe(sass({
+      outputStyle: 'expanded',
+      includePaths: [paths.fractalThemeScss + 'tech-docs-template']
+    }).on('error', sass.logError))
+    .pipe(gulp.dest(paths.fractalThemeCss))
+    // [1] Copy the theme assets to the static build location
+    .pipe(gulp.dest(paths.distFractal + 'theme/css'))
 })
 
-// TODO: Scripts
-// gulp.task('fractal:assets:scripts', () => {})
+// Scripts
+gulp.task('fractal:assets:scripts', () => {
+  return gulp.src(paths.fractalThemeJs + '**/*.js')
+    .pipe(gulp.dest(paths.distFractal + 'theme/scripts'))
+})
 
-// TODO: Images
-// gulp.task('fractal:assets:images', () => {})
+// Images
+gulp.task('fractal:assets:images', () => {
+  console.log('theme images copied')
+  return gulp.src(paths.fractalThemeImages + '*')
+    // [2] Copy the theme assets to the static build location
+    .pipe(gulp.dest(paths.distFractal + 'theme/images'))
+})

--- a/lib/tasks/fractal-assets.js
+++ b/lib/tasks/fractal-assets.js
@@ -23,7 +23,9 @@ gulp.task('fractal:assets:styles', () => {
      outputStyle: 'expanded',
      includePaths: [paths.fractalThemeScss + 'tech-docs-template']
    }).on('error', sass.logError))
-    .pipe(gulp.dest(paths.fractalThemeCss))
+  .pipe(gulp.dest(paths.fractalThemeCss))
+  // Copy the theme assets to the static build location
+  .pipe(gulp.dest(paths.distFractal + 'theme/css'))
 })
 
 // TODO: Scripts

--- a/lib/tasks/fractal-build.js
+++ b/lib/tasks/fractal-build.js
@@ -5,7 +5,6 @@ const gulp = require('gulp')
 const fractal = require('../../lib/fractal/config/fractal.js')
 // keep a reference to the fractal CLI console utility
 const logger = fractal.cli.console
-const paths = require('../../config/paths')
 
 /*
  * Run a static export of the project web UI.

--- a/lib/tasks/fractal-build.js
+++ b/lib/tasks/fractal-build.js
@@ -24,18 +24,5 @@ gulp.task('fractal:build', ['fractal:assets'], function () {
 
   return builder.build().then(() => {
     logger.success('Fractal build completed!')
-
-    // Fix theme assets not being copied, see below
-    copyThemeAssets()
   })
 })
-
-/*
- * Copy the theme assets to the static build location
- *
- * Fractal should do this, but it looks like a bug. Mentioned to
- * the fractal team and they're going to look into it.
- */
-const copyThemeAssets = () => {
-  gulp.src(paths.fractalThemeImages + '*').pipe(gulp.dest(paths.distFractal + 'theme/images'))
-}

--- a/lib/tasks/fractal-build.js
+++ b/lib/tasks/fractal-build.js
@@ -37,6 +37,5 @@ gulp.task('fractal:build', ['fractal:assets'], function () {
  * the fractal team and they're going to look into it.
  */
 const copyThemeAssets = () => {
-  gulp.src(paths.fractalThemeCss + '*.css').pipe(gulp.dest(paths.distFractal + 'theme/css'))
   gulp.src(paths.fractalThemeImages + '*').pipe(gulp.dest(paths.distFractal + 'theme/images'))
 }

--- a/lib/tasks/fractal-build.js
+++ b/lib/tasks/fractal-build.js
@@ -5,6 +5,7 @@ const gulp = require('gulp')
 const fractal = require('../../lib/fractal/config/fractal.js')
 // keep a reference to the fractal CLI console utility
 const logger = fractal.cli.console
+const paths = require('../../config/paths')
 
 /*
  * Run a static export of the project web UI.
@@ -16,11 +17,26 @@ const logger = fractal.cli.console
  * configuration option set above.
  */
 
-gulp.task('fractal:build', function () {
+gulp.task('fractal:build', ['fractal:assets'], function () {
   const builder = fractal.web.builder()
   builder.on('progress', (completed, total) => logger.update(`Exported ${completed} of ${total} items`, 'info'))
   builder.on('error', err => logger.error(err.message))
+
   return builder.build().then(() => {
     logger.success('Fractal build completed!')
+
+    // Fix theme assets not being copied, see below
+    copyThemeAssets()
   })
 })
+
+/*
+ * Copy the theme assets to the static build location
+ *
+ * Fractal should do this, but it looks like a bug. Mentioned to
+ * the fractal team and they're going to look into it.
+ */
+const copyThemeAssets = () => {
+  gulp.src(paths.fractalThemeCss + '*.css').pipe(gulp.dest(paths.distFractal + 'theme/css'))
+  gulp.src(paths.fractalThemeImages + '*').pipe(gulp.dest(paths.distFractal + 'theme/images'))
+}

--- a/lib/tasks/fractal-watch.js
+++ b/lib/tasks/fractal-watch.js
@@ -5,9 +5,9 @@ const gulp = require('gulp')
 
 // Watch tasks for the fractal theme assets
 gulp.task('fractal:watch', [
-  'watch:fractal:assets:styles'
-  // 'watch:fractal:assets:scripts',
-  // 'watch:fractal:assets:images'
+  'watch:fractal:assets:styles',
+  'watch:fractal:assets:scripts',
+  'watch:fractal:assets:images'
 ])
 
 // Watch scss files, call the fractal:theme:styles task to compile to css
@@ -16,12 +16,12 @@ gulp.task('watch:fractal:assets:styles', function () {
   return gulp.watch(paths.fractalThemeScss + '**/*.scss', ['fractal:assets:styles'])
 })
 
-// TODO: Watch theme scripts
-// gulp.task('watch:fractal:assets:scripts', function () {
-//   return gulp.watch(paths.fractalThemeJs + '**/*.js', ['fractal:theme:scripts'])
-// })
+// Watch theme scripts
+gulp.task('watch:fractal:assets:scripts', function () {
+  return gulp.watch(paths.fractalThemeJs + '**/*.js', ['fractal:assets:scripts'])
+})
 
-// TODO: Watch theme images
-// gulp.task('watch:fractal:assets:images', function () {
-//   return gulp.watch(paths.fractalThemeImg + '**/*', ['fractal:theme:images'])
-// })
+// Watch theme images
+gulp.task('watch:fractal:assets:images', function () {
+  return gulp.watch(paths.fractalThemeImg + '**/*', ['fractal:assets:images'])
+})


### PR DESCRIPTION
#### What does it do

Ensure that theme assets are copied to the static build location (copied from #114).
These tasks are moved to sit with the other theme tasks.

Also add watch tasks for the theme assets, these will trigger the build tasks to copy assets.

#### What type of change is it?
- New feature (non-breaking change which adds functionality)
