### PR TITLE
Fix gem by copying Sass into the correct place during build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,7 +47,7 @@ gulp.task('lint', ['lint:styles', 'lint:scripts', 'lint:tests'])
 
 // Task to run the tests
 gulp.task('test', cb => {
-  runSequence('lint', 'test:lib', 'test:components', 'test:toolkit', 'fractal:test', cb)
+  runSequence('lint', 'test:smoke', 'test:lib', 'test:components', 'test:toolkit', 'fractal:test', cb)
 })
 
 // Package the contents of dist

--- a/lib/tasks/build-styles.js
+++ b/lib/tasks/build-styles.js
@@ -16,11 +16,18 @@ gulp.task('build:styles', cb => {
 })
 
 gulp.task('build:styles:copy', cb => {
-  gulp.src(paths.assetsScss + '**/*.scss').pipe(gulp.dest(paths.bundleScss))
-  gulp.src(paths.srcComponents + '**/*.scss')
+  runSequence('build:styles:copy:scss', 'build:styles:copy:components', cb)
+})
+
+gulp.task('build:styles:copy:scss', () => {
+  return gulp.src(paths.assetsScss + '**/*.scss')
+    .pipe(gulp.dest(paths.bundleScss))
+})
+
+gulp.task('build:styles:copy:components', () => {
+  return gulp.src(paths.srcComponents + '**/*.scss')
     .pipe(flatten())
     .pipe(gulp.dest(paths.bundleScss + 'components'))
-  return cb()
 })
 
 gulp.task('build:styles:compile', () => {

--- a/lib/tasks/build-styles.js
+++ b/lib/tasks/build-styles.js
@@ -5,29 +5,30 @@ const paths = require('../../config/paths.json')
 const gulp = require('gulp')
 const runSequence = require('run-sequence')
 const rename = require('gulp-rename')
+const flatten = require('gulp-flatten')
 
 const sass = require('gulp-sass')
 const nano = require('gulp-cssnano')
 
 // Compile Sass to CSS
 gulp.task('build:styles', cb => {
-  runSequence('lint:styles', [
-    'build:styles:copy',
-    'build:styles:compile'
-  ], cb)
+  runSequence('lint:styles', 'build:styles:copy', 'build:styles:compile', cb)
+})
+
+gulp.task('build:styles:copy', cb => {
+  gulp.src(paths.assetsScss + '**/*.scss').pipe(gulp.dest(paths.bundleScss))
+  gulp.src(paths.srcComponents + '**/*.scss')
+    .pipe(flatten())
+    .pipe(gulp.dest(paths.bundleScss + 'components'))
+  return cb()
 })
 
 gulp.task('build:styles:compile', () => {
-  return gulp.src(paths.assetsScss + '**/*.scss')
-    .pipe(sass().on('error', sass.logError))
+  return gulp.src(paths.bundleScss + '**/*.scss')
+    .pipe(sass.sync().on('error', sass.logError))
     .pipe(gulp.dest(paths.bundleCss))
     .pipe(gulp.dest(paths.publicCss))
     .pipe(rename({ suffix: '.min' }))
     .pipe(nano())
     .pipe(gulp.dest(paths.bundleCss))
-})
-gulp.task('build:styles:copy', cb => {
-  gulp.src(paths.assetsScss + '**/*.scss')
-    .pipe(gulp.dest(paths.bundleScss))
-  return cb()
 })

--- a/lib/tasks/build-styles.js
+++ b/lib/tasks/build-styles.js
@@ -26,7 +26,8 @@ gulp.task('build:styles:compile', () => {
     .pipe(nano())
     .pipe(gulp.dest(paths.bundleCss))
 })
-gulp.task('build:styles:copy', () => {
-  return gulp.src(paths.assetsScss + '**/*.scss')
+gulp.task('build:styles:copy', cb => {
+  gulp.src(paths.assetsScss + '**/*.scss')
     .pipe(gulp.dest(paths.bundleScss))
+  return cb()
 })

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -3,6 +3,7 @@
 const paths = require('../../config/paths.json')
 
 const gulp = require('gulp')
+const runSequence = require('run-sequence')
 
 const mocha = require('gulp-mocha')
 const jasmineBrowser = require('gulp-jasmine-browser')
@@ -13,9 +14,16 @@ gulp.task('test:lib', () => gulp.src(paths.testSpecs + 'transpiler_spec.js', {re
 )
 
 gulp.task('test:components', () => gulp.src([
-  paths.testSpecs + 'components/' + '**/*',
+  paths.testSpecs + 'components/helper.js',
   paths.srcComponents + '**/*.spec.js'
 ], {read: false})
+  .pipe(mocha({reporter: 'spec'}))
+)
+
+gulp.task('test:smoke', cb => {
+  runSequence('build:styles:copy', 'test:smoke:run', cb)
+})
+gulp.task('test:smoke:run', () => gulp.src(paths.testSpecs + 'smoke_spec.js', {read: false})
   .pipe(mocha({reporter: 'spec'}))
 )
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",
     "gulp-cssnano": "^2.1.2",
+    "gulp-flatten": "^0.3.1",
     "gulp-jasmine-browser": "^1.7.0",
     "gulp-mocha": "^3.0.1",
     "gulp-nodemon": "^2.2.1",

--- a/src/assets/scss/_components.scss
+++ b/src/assets/scss/_components.scss
@@ -3,12 +3,12 @@
 
 @import "components/box";
 @import "components/breadcrumb";
-@import "../../components/button/button";
+@import "components/button";
 @import "components/details";
 @import "components/external-links";
-@import "../../components/form-radio-group/form-radio-group";
+@import "components/form-radio-group";
 @import "components/form-date";
-@import "../../components/form-group/form-group";
+@import "components/form-group";
 @import "components/form-validation";
 @import "components/global-footer";
 @import "components/global-header";
@@ -18,7 +18,7 @@
 @import "components/message-bar";
 @import "components/notice";
 @import "components/panel";
-@import "../../components/phase-banner/phase-banner";
+@import "components/phase-banner";
 @import "components/phase-tag";
 @import "components/step";
 @import "components/tables";

--- a/test/specs/smoke_spec.js
+++ b/test/specs/smoke_spec.js
@@ -1,6 +1,14 @@
+'use strict'
+
 const expect = require('chai').expect
+
+// Components
 const nunjucks = require('nunjucks')
-const components = require('../../../lib/components')
+const components = require('../../lib/components')
+
+// Styles
+const paths = require('../../config/paths.json')
+const sass = require('node-sass')
 
 const expectComponentRenders = (name, input) => {
   let componentPath = components.templatePathFor(name)
@@ -9,7 +17,7 @@ const expectComponentRenders = (name, input) => {
   }).to.not.throw()
 }
 
-describe('All components variants render without errrors', () => {
+describe('All components variants render without errors', () => {
   Object.keys(components.all).map(name => {
     describe(`${name}`, () => {
       let variants = components.getVariantsFor(name)
@@ -19,6 +27,17 @@ describe('All components variants render without errrors', () => {
           expectComponentRenders(name, variant.context)
         })
       }
+    })
+  })
+})
+
+describe('Styles', () => {
+  it('should compile', done => {
+    sass.render({
+      file: paths.bundleScss + 'govuk-frontend.scss'
+    }, error => {
+      expect(error).to.equal(null)
+      done()
     })
   })
 })


### PR DESCRIPTION
Moving the component Sass into the owner’s directories meant that the Gem could no longer reference it correctly. This copies the component Sass back into the dist’s scss folder during the build process and reverts the manifest back to the original references.

It also introduces a Sass compilation smoke test that will fail if the Sass fails to compile.