### PR TITLE
Add an example of `prose` - with scoped element styles

### DIFF
--- a/config/paths.json
+++ b/config/paths.json
@@ -2,6 +2,7 @@
   "config": "config/",
   "src": "src",
   "srcComponents": "src/components/",
+  "srcScopes": "src/components/scopes/",
   "srcDocs": "src/docs/",
   "assetsImg": "src/assets/images/",
   "assetsJs": "src/assets/js/",

--- a/lib/tasks/build-styles.js
+++ b/lib/tasks/build-styles.js
@@ -16,7 +16,7 @@ gulp.task('build:styles', cb => {
 })
 
 gulp.task('build:styles:copy', cb => {
-  runSequence('build:styles:copy:scss', 'build:styles:copy:components', cb)
+  runSequence('build:styles:copy:scss', 'build:styles:copy:components', 'build:styles:copy:scopes', cb)
 })
 
 gulp.task('build:styles:copy:scss', () => {
@@ -28,6 +28,12 @@ gulp.task('build:styles:copy:components', () => {
   return gulp.src(paths.srcComponents + '**/*.scss')
     .pipe(flatten())
     .pipe(gulp.dest(paths.bundleScss + 'components'))
+})
+
+gulp.task('build:styles:copy:scopes', () => {
+  return gulp.src(paths.srcScopes + '**/**/*.scss')
+    .pipe(flatten())
+    .pipe(gulp.dest(paths.bundleScss + 'scopes'))
 })
 
 gulp.task('build:styles:compile', () => {

--- a/src/assets/scss/_scopes.scss
+++ b/src/assets/scss/_scopes.scss
@@ -1,3 +1,4 @@
 // Add a scope layer
 // This can be used for cms content (e.g. govuk-govspeak)
-// @import "scope/govspeak"
+
+@import "scopes/prose"

--- a/src/assets/scss/components/_typography.scss
+++ b/src/assets/scss/components/_typography.scss
@@ -14,24 +14,6 @@
   color: $secondary-text-colour;
 }
 
-// Link styles
-.gv-link {
-  color: $link-colour;
-  text-decoration: underline;
-}
-
-.gv-link:visited {
-  color: $link-visited-colour;
-}
-
-.gv-link:hover {
-  color: $link-hover-colour;
-}
-
-.gv-link:active {
-  color: $link-colour;
-}
-
 // Back link styles - with left pointing arrow
 
 .gv-link-back {
@@ -81,32 +63,4 @@
     background: file-url("icon-arrow-left.png") no-repeat 0 4px;
   }
 
-}
-
-// Code styles
-.gv-code {
-  color: $text-colour;
-  background-color: $highlight-colour;
-
-  text-shadow: 0 1px $page-colour;
-  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
-  font-size: 14px;
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-  line-height: 1.5;
-
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
-
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-
-  border: 1px solid $border-colour;
-  padding: 4px 4px 2px;
 }

--- a/src/assets/scss/govuk-frontend.scss
+++ b/src/assets/scss/govuk-frontend.scss
@@ -4,4 +4,5 @@
 @import "elements";
 @import "objects";
 @import "components";
+@import "scopes";
 @import "utilities";

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -22,7 +22,6 @@
 
   cursor: pointer;
 
-  -webkit-font-smoothing: antialiased;
   -webkit-appearance: none;
 
   // Bottom edge effect

--- a/src/components/scopes/prose/README.md
+++ b/src/components/scopes/prose/README.md
@@ -1,0 +1,4 @@
+[//]: # (This text appears in the "Notes" tab in Fractal)
+
+
+

--- a/src/components/scopes/prose/_prose.scss
+++ b/src/components/scopes/prose/_prose.scss
@@ -1,0 +1,126 @@
+.gv-s-prose {
+
+  -webkit-font-smoothing: antialiased;
+
+  // Headings
+  h2 {
+    @include bold-36();
+
+    margin-top: em(25, 24);
+    margin-bottom: em(10, 24);
+
+    @include media(tablet) {
+      margin-top: em(45, 36);
+      margin-bottom: em(20, 36);
+    }
+  }
+
+  h3 {
+    @include bold-24();
+
+    margin-top: em(25, 20);
+    margin-bottom: em(10, 20);
+
+    @include media(tablet) {
+      margin-top: em(45, 24);
+      margin-bottom: em(20, 24);
+    }
+  }
+
+  h4 {
+    @include bold-19();
+
+    margin-top: em(10, 16);
+    margin-bottom: em(5, 16);
+
+    @include media(tablet) {
+      margin-top: em(20, 19);
+    }
+
+  }
+
+  // Body copy
+  p {
+    @include core-19;
+
+    margin-bottom: 20px;
+  }
+
+  // Lede, or intro text
+  p:first-child {
+    @include core-24;
+  }
+
+  // Lists
+  ul,
+  ol {
+    @include core-19;
+
+    margin-bottom: 20px;
+    padding: 0;
+  }
+
+  ul li,
+  ol li {
+    margin-bottom: 5px;
+  }
+
+  ul li {
+    list-style-type: disc;
+  }
+
+  ol li {
+    list-style-type: decimal;
+  }
+
+  // Link styles
+  a {
+    color: $link-colour;
+    text-decoration: underline;
+  }
+
+  a:visited {
+    color: $link-visited-colour;
+  }
+
+  a:hover {
+    color: $link-hover-colour;
+  }
+
+  a:active {
+    color: $link-colour;
+  }
+
+  // Bold text
+  strong {
+    font-weight: 700;
+  }
+
+  // Code styles
+  code {
+    color: $text-colour;
+    background-color: $highlight-colour;
+
+    text-shadow: 0 1px $page-colour;
+    font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+    font-size: 14px;
+    direction: ltr;
+    text-align: left;
+    white-space: pre;
+    word-spacing: normal;
+    word-break: normal;
+    line-height: 1.5;
+
+    -moz-tab-size: 4;
+    -o-tab-size: 4;
+    tab-size: 4;
+
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    -ms-hyphens: none;
+    hyphens: none;
+
+    border: 1px solid $border-colour;
+    padding: 4px 4px 2px;
+  }
+}

--- a/src/components/scopes/prose/_prose.scss
+++ b/src/components/scopes/prose/_prose.scss
@@ -1,6 +1,5 @@
 .gv-s-prose {
 
-  -webkit-font-smoothing: antialiased;
 
   // Headings
   h2 {

--- a/src/components/scopes/prose/_prose.scss
+++ b/src/components/scopes/prose/_prose.scss
@@ -2,6 +2,18 @@
 
 
   // Headings
+  h1 {
+    @include bold-48();
+
+    margin-top: em(15, 32);
+    margin-bottom: em(30, 32);
+
+    @include media(tablet) {
+      margin-top: em(30, 48);
+      margin-bottom: em(60, 48);
+    }
+  }
+
   h2 {
     @include bold-36();
 

--- a/src/components/scopes/prose/prose.config.js
+++ b/src/components/scopes/prose/prose.config.js
@@ -5,6 +5,7 @@ module.exports = {
     name: 'default',
     context: {
       content: '\n' +
+      '<h1>A 48px heading</h1>\n' +
       '<p>\n' +
       'This is an intro paragraph at 24px. Maecenas faucibus mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Curabitur blandit tempus porttitor. Vestibulum id ligula porta felis euismod semper.\n' +
       '</p>\n' +

--- a/src/components/scopes/prose/prose.config.js
+++ b/src/components/scopes/prose/prose.config.js
@@ -1,0 +1,41 @@
+module.exports = {
+  title: 'Prose',
+  status: 'wip',
+  variants: [{
+    name: 'default',
+    context: {
+      content: '\n' +
+      '<p>\n' +
+      'This is an intro paragraph at 24px. Maecenas faucibus mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Curabitur blandit tempus porttitor. Vestibulum id ligula porta felis euismod semper.\n' +
+      '</p>\n' +
+      '<h2>A 36px heading</h2>\n' +
+      '<p>\n' +
+        'This is a body copy paragraph at 19px. Donec id elit non mi porta gravida at eget metus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec sed odio dui. Aenean lacinia bibendum nulla sed consectetur. Aenean lacinia bibendum nulla sed consectetur. Sed posuere consectetur est at lobortis.\n' +
+      '</p>\n' +
+      '<h3>A 24px heading</h3>\n' +
+      '<p>\n' +
+        'Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum. Vestibulum id ligula porta felis euismod semper. Donec id elit non mi porta gravida at eget metus.\n' +
+      '</p>\n' +
+      '<h4>A 19px heading</h4>\n' +
+      '<p>\n' +
+        'Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.\n' +
+      '</p>\n' +
+      '<ul>\n' +
+        '<li>here is a bulleted list</li>\n' +
+        '<li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>\n' +
+        '<li>vestibulum id ligula porta felis euismod semper</li>\n' +
+        '<li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>\n' +
+      '</ul>\n' +
+      '<ol>\n' +
+        '<li>here is a numbered list</li>\n' +
+        '<li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>\n' +
+        '<li>vestibulum id ligula porta felis euismod semper</li>\n' +
+        '<li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>\n' +
+      '</ol>\n' +
+      '<p>\n' +
+        'Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.\n' +
+      '</p>'
+    }
+  }]
+}
+

--- a/src/components/scopes/prose/prose.html
+++ b/src/components/scopes/prose/prose.html
@@ -1,0 +1,3 @@
+<div class="gv-s-prose">
+  {{ content }}
+</div>

--- a/src/components/scopes/prose/prose.njk
+++ b/src/components/scopes/prose/prose.njk
@@ -1,0 +1,3 @@
+<div class="gv-s-prose">
+  {{ content }}
+</div>


### PR DESCRIPTION
Scope typographic styles to `.gv-s-prose`. 

(We could change this to be `.text`, or any other class that makes sense for a wrapper for text elements, I've used `.prose` for now).

Add the [Typography - Example page](https://govuk-elements.herokuapp.com/typography/example-typography/) content from GOV.UK elements to the config file, to test that these elements are styled correctly without classes.

#### Screenshots (if appropriate):
![prose default gov uk frontend alpha](https://cloud.githubusercontent.com/assets/417754/21929957/5c1c9be4-d98b-11e6-8cee-837ab42ad7a9.png)


#### What type of change is it?
- New feature (non-breaking change which adds functionality)
