### PR TITLE
Fix the static build of Fractal

### DIFF
--- a/lib/fractal/govuk-theme/assets/scss/fractal-govuk-theme.scss
+++ b/lib/fractal/govuk-theme/assets/scss/fractal-govuk-theme.scss
@@ -1,6 +1,6 @@
 @charset "utf-8";
 
-$path: '/theme/images/';
+$path: '../images/';
 
 // Start: GOV.UK tech docs template scss
 $tablet-breakpoint: 768px !default;

--- a/lib/fractal/govuk-theme/index.js
+++ b/lib/fractal/govuk-theme/index.js
@@ -28,7 +28,7 @@ const customTheme = mandelbrot({
   // The URL of a stylesheet to apply the to the UI
   styles: [
     'default', // link to the default mandelbrot stylesheet
-    '/theme/css/fractal-govuk-theme.css' // override with a custom stylesheet
+    'theme/govuk/css/fractal-govuk-theme.css' // override with a custom stylesheet
   ],
   // Virtual path prefix for the theme’s static assets. The value of this is prepended to the generated theme static asset URLs.
   'static': {
@@ -40,7 +40,7 @@ const customTheme = mandelbrot({
 customTheme.addLoadPath(path.join(__dirname, 'views'))
 
 // Specify the static assets directory that contains the custom stylesheet
-customTheme.addStatic(path.join(__dirname, 'assets'), '/theme')
+customTheme.addStatic(path.join(__dirname, 'assets'), 'theme/govuk')
 
 // Export the customised theme instance so it can be used in Fractal projects
 module.exports = customTheme

--- a/lib/fractal/govuk-theme/views/partials/header.nunj
+++ b/lib/fractal/govuk-theme/views/partials/header.nunj
@@ -5,7 +5,7 @@
     <div class="header__brand">
       <a href="/">
         <span class="govuk-logo">
-          <img class="govuk-logo__printable-crown" src="/theme/images/gov.uk_logotype_crown_invert_trans.png" height="32" width="36">
+          <img class="govuk-logo__printable-crown" src="/theme/govuk/images/gov.uk_logotype_crown_invert_trans.png" height="32" width="36">
           GOV.UK
         </span>
         <span class="header__title">

--- a/lib/tasks/fractal-build.js
+++ b/lib/tasks/fractal-build.js
@@ -16,10 +16,11 @@ const logger = fractal.cli.console
  * configuration option set above.
  */
 
-gulp.task('fractal:build', function () {
+gulp.task('fractal:build', ['build', 'fractal:assets'], function () {
   const builder = fractal.web.builder()
   builder.on('progress', (completed, total) => logger.update(`Exported ${completed} of ${total} items`, 'info'))
   builder.on('error', err => logger.error(err.message))
+
   return builder.build().then(() => {
     logger.success('Fractal build completed!')
   })


### PR DESCRIPTION
- Use a different theme path, `theme` is used internally by Fractal,
  so was causing a race condition with Fractal copying it's own
  assets. Use a different name to avoid that, see this issue for
  more info: https://github.com/frctl/fractal/issues/200

- Avoid absolute paths, use relative paths where possible, so that
  the static styleguide works when run from the filesystem, rather
  than from /

- Ensure that `build` has been run before running the fractal build,
  so the built layout/component CSS can be pulled into Fractal output

