### PR TITLE
Add a checkbox component

### DIFF
--- a/src/assets/scss/_components.scss
+++ b/src/assets/scss/_components.scss
@@ -6,6 +6,7 @@
 @import "components/button";
 @import "components/details";
 @import "components/external-links";
+@import "components/form-checkbox-group";
 @import "components/form-radio-group";
 @import "components/form-date";
 @import "components/form-group";

--- a/src/components/form-checkbox-group/_form-checkbox-group.scss
+++ b/src/components/form-checkbox-group/_form-checkbox-group.scss
@@ -1,0 +1,117 @@
+// Large hit area
+// Radio buttons & checkboxes
+
+// By default, block labels stack vertically
+.gv-c-form-custom {
+
+  display: block;
+  float: none;
+  clear: left;
+  position: relative;
+
+  padding: (8px $gutter-one-third 9px 50px);
+  margin-bottom: $gutter-one-third;
+
+  cursor: pointer; // Encourage clicking on block labels
+
+  // remove 300ms pause on mobile
+  -ms-touch-action: manipulation;
+  touch-action: manipulation;
+
+  @include media(tablet) {
+    float: left;
+    padding-top: 7px;
+    padding-bottom: 7px;
+    // width: 25%; - Test : check that text within labels will wrap
+  }
+
+  // Absolutely position inputs within label, to allow text to wrap
+  &__control {
+    position: absolute;
+    cursor: pointer;
+    left: 0;
+    top: 0;
+    width: 38px;
+    height: 38px;
+
+    // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there.
+    @if ($is-ie == false) or ($ie-version == 9) {
+      .js-enabled & {
+        margin: 0;
+        @include opacity(0);
+      }
+    }
+  }
+
+  .js-enabled & {
+
+    &.selection-button-checkbox::before {
+      content: "";
+      border: 2px solid;
+      background: transparent;
+      width: 34px;
+      height: 34px;
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
+
+    &.selection-button-checkbox::after {
+      content: "";
+      border: solid;
+      border-width: 0 0 5px 5px;
+      background: transparent;
+      width: 17px;
+      height: 7px;
+      position: absolute;
+      top: 10px;
+      left: 8px;
+      -moz-transform: rotate(-45deg); // Firefox 15 compatibility
+      -o-transform: rotate(-45deg); // Opera 12.0 compatibility
+      -webkit-transform: rotate(-45deg); // Safari 8 compatibility
+      -ms-transform: rotate(-45deg); // IE9 compatibility
+      transform: rotate(-45deg);
+      @include opacity(0);
+    }
+
+    // Focused state
+    &.selection-button-checkbox {
+      &.focused::before {
+        @include box-shadow(0 0 0 5px $focus-colour);
+      }
+      // IE8 focus outline should stay as a border around the entire label
+      // Lack of padding doesn’t matter as IE8 won’t resize the inputs.
+      @include ie-lte(8) {
+        &.focused {
+          outline: 3px solid $focus-colour;
+
+          input:focus {
+            outline: none;
+          }
+        }
+      }
+    }
+
+    // Selected state
+    &.selection-button-checkbox {
+      &.selected::after {
+        @include opacity(1);
+      }
+    }
+  }
+
+  &:last-child,
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+}
+
+// To stack horizontally, use .inline on parent, to sit block labels next to each other
+.inline .block-label {
+  clear: none;
+
+  @include media (tablet) {
+    margin-bottom: 0;
+    margin-right: $gutter;
+  }
+}

--- a/src/components/form-checkbox-group/form-checkbox-group.config.js
+++ b/src/components/form-checkbox-group/form-checkbox-group.config.js
@@ -1,0 +1,49 @@
+module.exports = {
+  title: 'Form checkbox group',
+  status: 'wip',
+  context: {
+    setup: {
+      initScript: 'var $blockLabels = $(".gv-c-form-custom input[type=\'checkbox\']"); new GOVUK.SelectionButtons($blockLabels);',
+      openWrapper: '<form>',
+      closeWrapper: '</form>'
+    },
+    id: 'contact',
+    name: 'contact-group',
+    legend: 'How do you want to be contacted?',
+    hint: '',
+    error: '',
+    checkboxGroup: [{
+      id: 'example-contact-by-email',
+      value: 'contact-by-email',
+      label: 'Email'
+    }, {
+      id: 'example-contact-by-phone',
+      value: 'contact-by-phone',
+      label: 'Phone'
+    }, {
+      id: 'example-contact-by-text',
+      value: 'contact-by-text',
+      label: 'Text'
+    }]
+  },
+  variants: [{
+    name: 'has hint',
+    context: {
+      hint: 'Hint text in here'
+    }
+  },
+  {
+    name: 'has error',
+    context: {
+      error: 'Error text in here'
+    }
+  },
+  {
+    name: 'has hint and error',
+    context: {
+      hint: 'Hint text in here',
+      error: 'Error text in here'
+    }
+  }],
+  arguments: ['id', 'name', 'legend', 'hint', 'error', 'checkboxGroup']
+}

--- a/src/components/form-checkbox-group/form-checkbox-group.njk
+++ b/src/components/form-checkbox-group/form-checkbox-group.njk
@@ -1,0 +1,26 @@
+<div class="gv-c-form-group {% if error %}gv-c-form-group--has-error{% endif %}">
+  <fieldset>
+
+    <legend>
+      <span class="gv-c-form-group__label">{{ legend }}</span>
+      {% if hint %}
+        <span class="gv-c-form-group__hint">{{ hint }}</span>
+      {% endif %}
+      {% if error %}
+        <span class="gv-c-form-group__error-message">{{ error }}</span>
+      {% endif %}
+    </legend>
+
+    {% for checkbox in checkboxGroup %}
+      <label class="gv-c-form-custom selection-button-checkbox" for="{{checkbox.id}}">
+        <input class="gv-c-form-custom__control"
+               id="{{checkbox.id}}"
+               type="checkbox"
+               name="{{ id }}"
+               value="{{ checkbox.value }}" {% if value == checkbox.value %} checked{% endif %}>
+        {{ checkbox.label }}
+      </label>
+    {% endfor %}
+
+  </fieldset>
+</div>

--- a/src/components/form-checkbox-group/form-checkbox-group.spec.js
+++ b/src/components/form-checkbox-group/form-checkbox-group.spec.js
@@ -1,0 +1,47 @@
+const expectComponent = require('../../../test/specs/components/helper').expectComponent
+
+describe('Form checkbox group component', () => {
+  it('should render', () => {
+    expectComponent(
+      'form-checkbox-group',
+      {
+        'id': 'contact',
+        'name': 'contact-group',
+        'legend': 'How do you want to be contacted?',
+        'checkboxGroup': [
+          {
+            'id': 'example-contact-by-email',
+            'value': 'contact-by-email',
+            'label': 'Email'
+          },
+          {
+            'id': 'example-contact-by-phone',
+            'value': 'contact-by-phone',
+            'label': 'Phone'
+          },
+          {
+            'id': 'example-contact-by-text',
+            'value': 'contact-by-text',
+            'label': 'Text'
+          }
+        ]
+      },
+      `<div class="gv-c-form-group ">
+        <fieldset>
+          <legend>
+            <span class="gv-c-form-group__label">How do you want to be contacted?</span>
+          </legend>
+          <label class="gv-c-form-custom selection-button-checkbox" for="example-contact-by-email">
+            <input class="gv-c-form-custom__control" id="example-contact-by-email"
+            type="checkbox" name="contact" value="contact-by-email">Email</label>
+          <label class="gv-c-form-custom selection-button-checkbox" for="example-contact-by-phone">
+            <input class="gv-c-form-custom__control" id="example-contact-by-phone"
+            type="checkbox" name="contact" value="contact-by-phone">Phone</label>
+          <label class="gv-c-form-custom selection-button-checkbox" for="example-contact-by-text">
+            <input class="gv-c-form-custom__control" id="example-contact-by-text"
+            type="checkbox" name="contact" value="contact-by-text">Text</label>
+        </fieldset>
+      </div>`
+    )
+  })
+})

--- a/src/components/form-radio-group/form-radio-group.config.js
+++ b/src/components/form-radio-group/form-radio-group.config.js
@@ -3,7 +3,7 @@ module.exports = {
   status: 'wip',
   context: {
     setup: {
-      initScript: 'var $blockLabels = $(".gv-c-form-custom input[type=\'radio\'], .gv-c-form-custom input[type=\'checkbox\']"); new GOVUK.SelectionButtons($blockLabels);',
+      initScript: 'var $blockLabels = $(".gv-c-form-custom input[type=\'radio\']"); new GOVUK.SelectionButtons($blockLabels);',
       openWrapper: '<form>',
       closeWrapper: '</form>'
     },


### PR DESCRIPTION
Add a checkbox component, this works in the same way as the radio component - but has the selection-button-* class changed to checkbox. 

The init script will now only initialise checkboxes and the init script for radio button components has been updated as this was previously initialising the selection buttons for checkboxes too. 

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply: -->
- New feature (non-breaking change which adds functionality)
