### PR TITLE
Start Fractal with `npm start`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "scripts": {
-    "start": "gulp start",
+    "start": "gulp fractal",
     "lint": "standard",
     "test": "npm run lint && gulp test"
   },


### PR DESCRIPTION
`gulp start` isn’t a valid task anymore. I think the expected behaviour for `npm start` should be to start fractal, but I’m open to other possibilities.