### PR TITLE
Fix fractal theme not loading on non-root pages

### DIFF
--- a/lib/fractal/govuk-theme/index.js
+++ b/lib/fractal/govuk-theme/index.js
@@ -28,7 +28,7 @@ const customTheme = mandelbrot({
   // The URL of a stylesheet to apply the to the UI
   styles: [
     'default', // link to the default mandelbrot stylesheet
-    'theme/govuk/css/fractal-govuk-theme.css' // override with a custom stylesheet
+    '/theme/govuk/css/fractal-govuk-theme.css' // override with a custom stylesheet
   ],
   // Virtual path prefix for the theme’s static assets. The value of this is prepended to the generated theme static asset URLs.
   'static': {


### PR DESCRIPTION
This wasn't obviousy, as if you load the root page the path is fine,
and navigation within the app uses JS, so the assets stay loaded, but
if you refresh/load a non-root URL the path will fail.

Shame, because this makes it hard to run the static build 'in place'
and requires a web server to run.