### PR TITLE
Fix gem/rails package

### DIFF
--- a/lib/packaging/gem/lib/govuk_frontend_alpha.rb
+++ b/lib/packaging/gem/lib/govuk_frontend_alpha.rb
@@ -8,7 +8,9 @@ module GovukFrontendAlpha
         govuk-frontend*.css
         govuk-template*.css
         fonts*.css
-        govuk-template.js
+        govuk-template.min.js
+        toolkit.min.js
+        components.min.js
         ie-shim.js
         template/favicon.ico
         template/apple-touch-icon-120x120.png

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "html": "^1.0.0",
     "jasmine-spec-reporter": "^2.7.0",
     "jquery": "^3.1.1",
-    "meta-template": "https://github.com/dsingleton/meta-template/tarball/add-erb-support",
+    "meta-template": "https://github.com/dsingleton/meta-template/tarball/default-filter",
     "nunjucks": "^2.5.2",
     "phantomjs-prebuilt": "^2.1.13",
     "rollup-stream": "^1.14.0",


### PR DESCRIPTION
- Adds missing assets to the precompile list, this was causing an error (long term those assets should be programatically computed, or derived from a manifest)
- Use a fork of meta-template to get around issues with `default`

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply: -->
- Bug fix (non-breaking change which fixes an issue)
