### PR TITLE
Details html content

### DIFF
--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -18,7 +18,7 @@ Call **details** like a normal function, set values for arguments `'summary', 't
 {% raw %}
 {{ govuk_components.details(
   summary="Summary text goes in here",
-  details="Details text goes in here"
+  content="Details text goes in here"
 ) }}
 {% endraw %}
 ```
@@ -27,7 +27,7 @@ Call **details** like a normal function, set values for arguments `'summary', 't
 {% raw %}
 {{ govuk_components.details(
   summary="Summary text goes in here",
-  detailsHtml="<p>We need to know your nationality so we can work out which elections you’re entitled to vote in.</p> <a href="#">I can’t provide my nationality</a>"
+  contentHtml="<p>We need to know your nationality so we can work out which elections you’re entitled to vote in.</p> <a href=\"#\">I can’t provide my nationality</a>"
 ) }}
 {% endraw %}
 ```

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -18,7 +18,16 @@ Call **details** like a normal function, set values for arguments `'summary', 't
 {% raw %}
 {{ govuk_components.details(
   summary="Summary text goes in here",
-  text="Details text goes in here"
+  details="Details text goes in here"
+) }}
+{% endraw %}
+```
+
+```nunjucks
+{% raw %}
+{{ govuk_components.details(
+  summary="Summary text goes in here",
+  detailsHtml="<p>We need to know your nationality so we can work out which elections you’re entitled to vote in.</p> <a href="#">I can’t provide my nationality</a>"
 ) }}
 {% endraw %}
 ```

--- a/src/components/details/details.config.js
+++ b/src/components/details/details.config.js
@@ -5,15 +5,15 @@ module.exports = {
     name: 'default',
     context: {
       summary: 'Summary text',
-      details: 'Details text'
+      content: 'Details text'
     }
   },
   {
     name: 'details_html',
     context: {
       summary: 'Summary text',
-      detailsHtml: '<p>We need to know your nationality so we can work out which elections you’re entitled to vote in.</p> <a href="#">I can’t provide my nationality</a>'
+      contentHtml: '<p>We need to know your nationality so we can work out which elections you’re entitled to vote in.</p> <a href="#">I can’t provide my nationality</a>'
     }
   }],
-  arguments: ['summary', 'details', 'detailsHtml']
+  arguments: ['summary', 'content', 'contentHtml']
 }

--- a/src/components/details/details.config.js
+++ b/src/components/details/details.config.js
@@ -1,9 +1,19 @@
 module.exports = {
   title: 'Details',
   status: 'wip',
-  context: {
-    summary: 'Summary text',
-    text: 'Details text'
+  variants: [{
+    name: 'default',
+    context: {
+      summary: 'Summary text',
+      details: 'Details text'
+    }
   },
-  arguments: ['summary', 'text']
+  {
+    name: 'details_html',
+    context: {
+      summary: 'Summary text',
+      detailsHtml: '<p>We need to know your nationality so we can work out which elections you’re entitled to vote in.</p> <a href="#">I can’t provide my nationality</a>'
+    }
+  }],
+  arguments: ['summary', 'details', 'detailsHtml']
 }

--- a/src/components/details/details.njk
+++ b/src/components/details/details.njk
@@ -3,6 +3,6 @@
     <span class="gv-c-details__summary-text">{{ summary }}</span>
   </summary>
   <div class="panel panel-border-narrow">
-    {{ text }}
+    {% if details %}{{ details }}{% else %}{{ detailsHtml|safe }}{% endif %}
   </div>
 </details>

--- a/src/components/details/details.njk
+++ b/src/components/details/details.njk
@@ -3,6 +3,11 @@
     <span class="gv-c-details__summary-text">{{ summary }}</span>
   </summary>
   <div class="panel panel-border-narrow">
-    {% if details %}{{ details }}{% else %}{{ detailsHtml|safe }}{% endif %}
+    {% if content %}
+      {{ content }}
+    {% endif %}
+    {% if contentHtml %}
+      {{ contentHtml | safe }}
+    {% endif %}
   </div>
 </details>

--- a/src/components/details/details.spec.js
+++ b/src/components/details/details.spec.js
@@ -6,7 +6,7 @@ describe('Details component', () => {
       'details',
       {
         summary: 'Summary text',
-        details: 'Details text'
+        content: 'Details text'
       },
       `<details class="gv-c-details">
         <summary class="gv-c-details__summary">
@@ -24,7 +24,7 @@ describe('Details component', () => {
       'details',
       {
         summary: 'Summary text',
-        detailsHtml: '<p>We need to know your nationality so we can work out which elections you’re entitled to vote in.</p> <a href="#">I can’t provide my nationality</a>'
+        contentHtml: '<p>We need to know your nationality so we can work out which elections you’re entitled to vote in.</p> <a href="#">I can’t provide my nationality</a>'
       },
       `<details class="gv-c-details">
         <summary class="gv-c-details__summary">

--- a/src/components/details/details.spec.js
+++ b/src/components/details/details.spec.js
@@ -5,8 +5,8 @@ describe('Details component', () => {
     expectComponent(
       'details',
       {
-        'summary': 'Summary text',
-        'text': 'Details text'
+        summary: 'Summary text',
+        details: 'Details text'
       },
       `<details class="gv-c-details">
         <summary class="gv-c-details__summary">
@@ -14,6 +14,24 @@ describe('Details component', () => {
         </summary>
         <div class="panel panel-border-narrow">
           Details text
+        </div>
+      </details>`
+    )
+  })
+
+  it('should allow trusted a HTML message', function () {
+    expectComponent(
+      'details',
+      {
+        summary: 'Summary text',
+        detailsHtml: '<p>We need to know your nationality so we can work out which elections you’re entitled to vote in.</p> <a href="#">I can’t provide my nationality</a>'
+      },
+      `<details class="gv-c-details">
+        <summary class="gv-c-details__summary">
+          <span class="gv-c-details__summary-text">Summary text</span>
+        </summary>
+        <div class="panel panel-border-narrow">
+          <p>We need to know your nationality so we can work out which elections you’re entitled to vote in.</p> <a href="#">I can’t provide my nationality</a>
         </div>
       </details>`
     )


### PR DESCRIPTION
Amend the details component to allow HTML content

Beware! Using a component's name within it's context will cause the `gulp test:lib` task to fail.

This is fixed in the second commit by renaming `details` and `detailsHtml` to `content` and `contentHtml`. 

#### What type of change is it?
- New feature (non-breaking change which adds functionality)
