### PR TITLE
"Getting started" docs - Using with node 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ You’re building a service that will live on GOV.UK. This will give your servic
 
 There are many ways to install GOV.UK Frontend.
 
-If you’re using NPM to manage packages then you can include the latest version directly in your project with the command `npm install govuk_frontend`.
+If you’re using NPM to manage packages then you can include the latest version directly in your project with the command `npm install govuk_frontend`. In the meantime you can [follow these instructions for NPM](docs/using-with-node.md).
 
-If you are building your project with Ruby then we publish this as a gem. Adding `govuk_frontend` to your Gemfile and running `bundle install` will install the latest version. In the mean time you can [follow these instructions](docs/using-with-rails.md).
+
+If you are building your project with Ruby then we publish this as a gem. Adding `govuk_frontend` to your Gemfile and running `bundle install` will install the latest version. In the meantime you can [follow these instructions](docs/using-with-rails.md).
 
 We publish a bundle of the code as a zip. This can be downloaded from [the latest release page](https://github.com/alphagov/govuk_elements/releases/latest), and manually copied into the right place for your system.
 

--- a/docs/template-blocks.md
+++ b/docs/template-blocks.md
@@ -1,0 +1,25 @@
+## GOV.UK template blocks and their default values
+
+| Template block name       |  Location / Information                         |   Default template values
+|---                        |---                                              |---
+| top_of_page               | Before doctype                                  | Insertion point
+| html_lang                 | value of the HTML lang attribute                | en
+| page_title                | Text inside the `<title>` element               | GOV.UK - The best place to find government services and information
+| head                      | Before closing `</head>` element                | Insertion point
+| body_classes              | Classes to be added to the `<body>` element     | Insertion point
+| body_start                | After opening `<body>` element                  | Insertion point
+| skip_link_message         | Text inside the skip to main content link       | Skip to main content
+| cookie_message            | Text inside the cookie message banner           | `<p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>`
+| header_class              | `<header>` element                              | Set the value of header_class to [with-proposition](https://github.com/alphagov/govuk_template/blob/master/docs/usage.md#propositional-title-and-navigation) to show the propositional navigation
+| homepage_url              | URL of anchor element wrapping logo             | https://www.gov.uk/
+| logo_link_title           | Title of anchor element wrapping logo           | Go to the GOV.UK homepage
+| global_header_text        | Text next to the crown image                    | GOV.UK
+| inside_header             | Inside parent `.header-global`                  | Insertion point
+| proposition_header        | Inside parent `.header-wrapper`                 | Add a [propositional title and navigation links](https://github.com/alphagov/govuk_template/blob/master/docs/usage.md#propositional-title-and-navigation)
+| after_header              | After closing `</header>` element               | Insertion point
+| content                   | Main content goes in here                       | Insertion point. Content must be wrapped with `id="content"` for the [skiplink to work](docs/usage.md#skip-link).
+| footer_top                | Inside parent `#footer-wrapper`                 | Insertion point
+| footer_support_links      | Inside parent `.footer-meta-inner`              | Insertion point
+| licence_message           | Open Government Licence text and link           | `<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>`
+| crown_copyright_message   | Copyright message                               | © Crown copyright
+| body_end                  | Before closing `</body>` element                | Insertion point

--- a/docs/using-with-node.md
+++ b/docs/using-with-node.md
@@ -1,0 +1,85 @@
+# Using with Node
+
+*Note: These instructions describe setting up the alpha version of govuk_frontend and can/will change*
+
+## Add to package.json
+
+From this repo, build a local version of the npm package:
+
+```bash
+gulp package
+```
+
+This will create a tgz file in `dist/npm/`
+
+Copy the govuk_frontend_alpha-0.0.1.tgz file to the root of your project.
+
+Amend your package.json file to include govuk_frontend_alpha as a dependency.
+
+```bash
+"dependencies": {
+ "govuk_frontend_alpha": "file:govuk_frontend_alpha-0.0.1.tgz"
+ }
+```
+
+Install the govuk_frontend_alpha package
+
+```bash
+npm install
+```
+
+Note: In future the package will be published to npm and the steps above can be replaced with
+
+```bash
+npm install govuk-frontend-alpha --save
+```
+
+## Use the layout
+
+Create a layout template (usually `app/views/layout.nunjucks`)
+
+These instructions assume use of the Nunjucks templating language.
+
+Add this line to the layout.njk file, to use the govuk_frontend_alpha's layout template
+
+```nunjucks
+{% extends "govuk_template.njk" %}
+```
+
+## Importing SASS
+
+In your main stylesheet `main.scss`, add this to the start:
+
+```scss
+@import '../../../node_modules/govuk_frontend_alpha/;
+```
+
+Or configure includePaths to include node_modules and use:
+
+```scss
+@import 'govuk_frontend_alpha/;
+```
+
+You will then need to include your main stylesheet in the `head` content block - see below.
+
+## Customise the template
+
+`govuk_template` provides blocks you can insert content into, to customise the basic layout.
+
+For example, to set a `<title>` for your page you can override the `page_title` block, and it will be inserted into the `govuk_template` layout.:
+
+```nunjucks
+{% block page_title %}
+  My project title
+{% endblock %}
+```
+
+Or to add content to `<head>`, for stylesheets or similar:
+
+```nujucks
+{% block head %}
+  <link href="/public/css/main.css" media="screen" rel="stylesheet" type="text/css">
+{% endblock %}
+```
+
+Check out the [full list of blocks](template-blocks.md) you can use to customise the template.


### PR DESCRIPTION
#### What does it do?

Adds "Getting started" with Node/Express documentation, following the style of the ["Using with rails" documentation](https://github.com/alphagov/govuk_frontend_alpha/blob/master/docs/using-with-rails.md).

These instructions include: 
- building the npm package
- including the package as a dependency in your project
- importing the sass files within your main stylesheet
- customising the template to include a main stylesheet in the head block

It also adds a list of template blocks - copied from the govuk_template documentation, for reference to other template blocks that can be overridden.

#### What type of change is it?
- New feature (non-breaking change which adds functionality)
