### PR TITLE
Add missing value argument to x-group components

### DIFF
--- a/src/components/form-checkbox-group/form-checkbox-group.config.js
+++ b/src/components/form-checkbox-group/form-checkbox-group.config.js
@@ -40,5 +40,5 @@ module.exports = {
       error: 'Error text in here'
     }
   }],
-  arguments: ['id', 'name', 'legend', 'hint', 'error', 'checkboxGroup']
+  arguments: ['id', 'name', 'legend', 'hint', 'error', 'checkboxGroup', 'value']
 }

--- a/src/components/form-radio-group/form-radio-group.config.js
+++ b/src/components/form-radio-group/form-radio-group.config.js
@@ -40,5 +40,5 @@ module.exports = {
       error: 'Error text in here'
     }
   }],
-  arguments: ['id', 'name', 'legend', 'hint', 'error', 'radioGroup']
+  arguments: ['id', 'name', 'legend', 'hint', 'error', 'radioGroup', 'value']
 }


### PR DESCRIPTION
This was causing an error in erb templates as 'value' isn't defined. erb
transpile uses the arguments values to map missing/default values.

There is a smoke test to catch components that define context exmaples
which include values missed from arguments, but this component doesn't
have any contexts using value yet - so didn't catch it :(

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply: -->
- Bug fix (non-breaking change which fixes an issue)
