### PR TITLE
Add option to visually hide legend text

### DIFF
--- a/src/components/form-checkbox-group/form-checkbox-group.config.js
+++ b/src/components/form-checkbox-group/form-checkbox-group.config.js
@@ -5,6 +5,7 @@ module.exports = {
     id: 'contact',
     name: 'contact-group',
     legend: 'How do you want to be contacted?',
+    legendIsVisuallyHidden: false,
     hint: '',
     error: '',
     checkboxGroup: [{
@@ -40,5 +41,5 @@ module.exports = {
       error: 'Error text in here'
     }
   }],
-  arguments: ['id', 'name', 'legend', 'hint', 'error', 'checkboxGroup', 'value']
+  arguments: ['id', 'name', 'legend', 'legendIsVisuallyHidden', 'hint', 'error', 'checkboxGroup', 'value']
 }

--- a/src/components/form-checkbox-group/form-checkbox-group.njk
+++ b/src/components/form-checkbox-group/form-checkbox-group.njk
@@ -2,7 +2,7 @@
   <fieldset>
 
     <legend>
-      <span class="gv-c-form-group__label">{{ legend }}</span>
+      <span class="gv-c-form-group__label {% if legendIsVisuallyHidden %}gv-u-visually-hidden{% endif %}">{{ legend }}</span>
       {% if hint %}
         <span class="gv-c-form-group__hint">{{ hint }}</span>
       {% endif %}

--- a/src/components/form-checkbox-group/form-checkbox-group.spec.js
+++ b/src/components/form-checkbox-group/form-checkbox-group.spec.js
@@ -8,6 +8,7 @@ describe('Form checkbox group component', () => {
         'id': 'contact',
         'name': 'contact-group',
         'legend': 'How do you want to be contacted?',
+        'legendIsVisuallyHidden': false,
         'checkboxGroup': [
           {
             'id': 'example-contact-by-email',
@@ -29,7 +30,58 @@ describe('Form checkbox group component', () => {
       `<div class="gv-c-form-group ">
         <fieldset>
           <legend>
-            <span class="gv-c-form-group__label">How do you want to be contacted?</span>
+            <span class="gv-c-form-group__label ">How do you want to be contacted?</span>
+          </legend>
+          <div class="gv-c-multiple-choice">
+            <input class="gv-c-multiple-choice__control" id="example-contact-by-email"
+            type="checkbox" name="contact" value="contact-by-email">
+            <label class="gv-c-multiple-choice__label" for="example-contact-by-email">Email</label>
+          </div>
+          <div class="gv-c-multiple-choice">
+            <input class="gv-c-multiple-choice__control" id="example-contact-by-phone"
+            type="checkbox" name="contact" value="contact-by-phone">
+            <label class="gv-c-multiple-choice__label" for="example-contact-by-phone">Phone</label>
+          </div>
+          <div class="gv-c-multiple-choice">
+            <input class="gv-c-multiple-choice__control" id="example-contact-by-text"
+            type="checkbox" name="contact" value="contact-by-text">
+            <label class="gv-c-multiple-choice__label" for="example-contact-by-text">Text</label>
+          </div>
+        </fieldset>
+      </div>`
+    )
+  })
+
+  it('should render with the legend text hidden', () => {
+    expectComponent(
+      'form-checkbox-group',
+      {
+        'id': 'contact',
+        'name': 'contact-group',
+        'legend': 'How do you want to be contacted?',
+        'legendIsVisuallyHidden': true,
+        'checkboxGroup': [
+          {
+            'id': 'example-contact-by-email',
+            'value': 'contact-by-email',
+            'label': 'Email'
+          },
+          {
+            'id': 'example-contact-by-phone',
+            'value': 'contact-by-phone',
+            'label': 'Phone'
+          },
+          {
+            'id': 'example-contact-by-text',
+            'value': 'contact-by-text',
+            'label': 'Text'
+          }
+        ]
+      },
+      `<div class="gv-c-form-group ">
+        <fieldset>
+          <legend>
+            <span class="gv-c-form-group__label gv-u-visually-hidden">How do you want to be contacted?</span>
           </legend>
           <div class="gv-c-multiple-choice">
             <input class="gv-c-multiple-choice__control" id="example-contact-by-email"

--- a/src/components/form-radio-group/form-radio-group.config.js
+++ b/src/components/form-radio-group/form-radio-group.config.js
@@ -5,6 +5,7 @@ module.exports = {
     id: 'contact',
     name: 'contact-group',
     legend: 'How do you want to be contacted?',
+    legendIsVisuallyHidden: false,
     hint: '',
     error: '',
     radioGroup: [{
@@ -40,5 +41,5 @@ module.exports = {
       error: 'Error text in here'
     }
   }],
-  arguments: ['id', 'name', 'legend', 'hint', 'error', 'radioGroup', 'value']
+  arguments: ['id', 'name', 'legend', 'legendIsVisuallyHidden', 'hint', 'error', 'radioGroup', 'value']
 }

--- a/src/components/form-radio-group/form-radio-group.njk
+++ b/src/components/form-radio-group/form-radio-group.njk
@@ -2,7 +2,7 @@
   <fieldset>
 
     <legend>
-      <span class="gv-c-form-group__label">{{ legend }}</span>
+      <span class="gv-c-form-group__label {% if legendIsVisuallyHidden %}gv-u-visually-hidden{% endif %}">{{ legend }}</span>
       {% if hint %}
         <span class="gv-c-form-group__hint">{{ hint }}</span>
       {% endif %}

--- a/src/components/form-radio-group/form-radio-group.spec.js
+++ b/src/components/form-radio-group/form-radio-group.spec.js
@@ -8,6 +8,7 @@ describe('Form radio group component', () => {
         'id': 'contact',
         'name': 'contact-group',
         'legend': 'How do you want to be contacted?',
+        'legendIsVisuallyHidden': false,
         'radioGroup': [
           {
             'id': 'example-contact-by-email',
@@ -29,7 +30,58 @@ describe('Form radio group component', () => {
       `<div class="gv-c-form-group ">
         <fieldset>
           <legend>
-            <span class="gv-c-form-group__label">How do you want to be contacted?</span>
+            <span class="gv-c-form-group__label ">How do you want to be contacted?</span>
+          </legend>
+          <div class="gv-c-multiple-choice">
+            <input class="gv-c-multiple-choice__control" id="example-contact-by-email"
+            type="radio" name="contact" value="contact-by-email">
+            <label class="gv-c-multiple-choice__label" for="example-contact-by-email">Email</label>
+          </div>
+          <div class="gv-c-multiple-choice">
+            <input class="gv-c-multiple-choice__control" id="example-contact-by-phone"
+            type="radio" name="contact" value="contact-by-phone">
+            <label class="gv-c-multiple-choice__label" for="example-contact-by-phone">Phone</label>
+          </div>
+          <div class="gv-c-multiple-choice">
+            <input class="gv-c-multiple-choice__control" id="example-contact-by-text"
+            type="radio" name="contact" value="contact-by-text">
+            <label class="gv-c-multiple-choice__label" for="example-contact-by-text">Text</label>
+          </div>
+        </fieldset>
+      </div>`
+    )
+  })
+
+  it('should render with the legend text hidden', () => {
+    expectComponent(
+      'form-radio-group',
+      {
+        'id': 'contact',
+        'name': 'contact-group',
+        'legend': 'How do you want to be contacted?',
+        'legendIsVisuallyHidden': true,
+        'radioGroup': [
+          {
+            'id': 'example-contact-by-email',
+            'value': 'contact-by-email',
+            'label': 'Email'
+          },
+          {
+            'id': 'example-contact-by-phone',
+            'value': 'contact-by-phone',
+            'label': 'Phone'
+          },
+          {
+            'id': 'example-contact-by-text',
+            'value': 'contact-by-text',
+            'label': 'Text'
+          }
+        ]
+      },
+      `<div class="gv-c-form-group ">
+        <fieldset>
+          <legend>
+            <span class="gv-c-form-group__label gv-u-visually-hidden">How do you want to be contacted?</span>
           </legend>
           <div class="gv-c-multiple-choice">
             <input class="gv-c-multiple-choice__control" id="example-contact-by-email"


### PR DESCRIPTION
GOV.UK elements has examples where the legend text that accompanies a set of radio buttons or checkboxes is visually hidden, as it duplicates the page heading.

This is seen on question pages, using the "One thing per page" pattern.

Add an option `legendIsVisuallyHidden` (verbose, but it says what it is) to hide the legend text for both radio and checkbox components.

#### What type of change is it?
- New feature (non-breaking change which adds functionality)
