### PR TITLE
Allow $path variable to be overridden

### DIFF
--- a/src/assets/scss/tools/_url-helpers.scss
+++ b/src/assets/scss/tools/_url-helpers.scss
@@ -17,5 +17,5 @@
 // If image-url is not defined (if we are not in a Rails environment)
 // Set a path to /public/images (this is used by the GOV.UK elements app)
 @if not(function-exists(image-url)) {
-  $path: "/images/";
+  $path: "/images/" !default;
 }


### PR DESCRIPTION
In #142, `$path` was changed from `/public/images` to `/images/`.

The npm consuming app needs $path to be /public/images, so allow $path to be overridden by using `!default`;

