### PR TITLE
Remove noisey console.log line inside smoke tests

### DIFF
--- a/test/specs/smoke_spec.js
+++ b/test/specs/smoke_spec.js
@@ -23,7 +23,6 @@ describe('All components variants render without errors', () => {
       let variants = components.getVariantsFor(name)
       for (let variant of variants) {
         it(`${variant.name}`, () => {
-          console.log(variant.context)
           expectComponentRenders(name, variant.context)
         })
       }


### PR DESCRIPTION
This was added for debugging at some point, but is making the test
output harder to read now.