### PR TITLE
Watch component asset paths too

### DIFF
--- a/lib/tasks/build-watch.js
+++ b/lib/tasks/build-watch.js
@@ -6,14 +6,25 @@ const gulp = require('gulp')
 gulp.task('watch', ['watch:styles', 'watch:scripts', 'watch:images'])
 
 gulp.task('watch:styles', function () {
-  return gulp.watch(paths.assetsScss + '**/*.scss', ['build:styles'])
+  return gulp.watch(
+    [
+      paths.assetsScss + '**/*.scss',
+      paths.srcComponents + '**/*.scss'
+    ],
+    ['build:styles']
+  )
 })
 
 gulp.task('watch:scripts', function () {
-  return gulp.watch(paths.assetsJs + '**/*.js', ['build:scripts'])
+  return gulp.watch(
+    [
+      paths.assetsJs + '**/*.js',
+      paths.srcComponents + '**/*.js'
+    ],
+    ['build:scripts']
+  )
 })
 
 gulp.task('watch:images', function () {
   return gulp.watch(paths.assetsImg + '**/*', ['build:images'])
 })
-


### PR DESCRIPTION
Watch was no longer catching SCSS/JS moved into the component
file structure, and wasn't getting rebuild/updating fractal.

The JS matcher works, but is too broad, and will trigger a
build if the config or spec JS is updated too. This doesn't
break anything, but it's probably not idea euther. Could
be refactored as with a more precice glob to exclude any
JS files with a double ext?