### PR TITLE
Remove the $path override from url-helpers

### DIFF
--- a/src/assets/scss/govuk-frontend.scss
+++ b/src/assets/scss/govuk-frontend.scss
@@ -1,3 +1,7 @@
+// Path to assets for use with the file-url function
+// in the tools/url-helpers partial
+$path: "/images/";
+
 @import "settings";
 @import "tools";
 @import "generic";

--- a/src/assets/scss/tools/_url-helpers.scss
+++ b/src/assets/scss/tools/_url-helpers.scss
@@ -13,9 +13,3 @@
   }
   @return $url;
 }
-
-// If image-url is not defined (if we are not in a Rails environment)
-// Set a path to /public/images (this is used by the GOV.UK elements app)
-@if not(function-exists(image-url)) {
-  $path: "/images/" !default;
-}


### PR DESCRIPTION
This PR will fix background images for this application.

It removes the check for the image-url function, this is no longer required.
It was [removed from govuk_elements](https://github.com/alphagov/govuk_elements/commit/fb11c706e52bd81a74dc5c377f2edcd212d7a0ea) and accidentally copied to this repo.

This change requires $path to be defined on a project-by-project basis.

$path is set at the top of `src/assets/scss/govuk-frontend.scss` (for this application).

It is overridden in the [npm_test consuming application](https://github.com/alphagov/govuk_frontend_alpha_npm_test/blob/master/app/assets/scss/style.scss#L4).





