### PR TITLE
Collate component variants

### DIFF
--- a/lib/fractal/config/fractal.js
+++ b/lib/fractal/config/fractal.js
@@ -22,8 +22,8 @@ fractal.components.engine(nunjucks)
 // Specify a preview layout for a component
 fractal.components.set('default.preview', '@preview')
 
-// Don't collate variants for rendered previews
-fractal.components.set('default.collated', false)
+// Collate variants for rendered previews
+fractal.components.set('default.collated', true)
 
 // Set a default status for all components (TODO: default to WIP?)
 // fractal.components.set('default.status', null);


### PR DESCRIPTION
This ensures all a component's variants appear in its preview and removes
the variants from the left hand navigation.

#### Screenshots (if appropriate):

#### Before

![before](https://cloud.githubusercontent.com/assets/417754/22261789/30af6d72-e266-11e6-88c6-4400ffe963a0.png)

#### After
![after](https://cloud.githubusercontent.com/assets/417754/22261781/2b655d54-e266-11e6-8419-5e5117c52b21.png)




