### PR TITLE
Make the rails component helper more consistent with nunjucks component calls

### DIFF
--- a/lib/packaging/gem/lib/govuk_frontend_alpha.rb
+++ b/lib/packaging/gem/lib/govuk_frontend_alpha.rb
@@ -27,8 +27,23 @@ module GovukFrontendAlpha
   end
 
   module ApplicationHelper
-    def govuk_component(name, props)
-      render partial: "components/#{name}", locals: props.with_indifferent_access
+    def govuk_component
+      # allows components to be called like this:
+      # `govuk_component.button(text: 'Start now')`
+      DynamicComponentRenderer.new(self)
+    end
+
+    class DynamicComponentRenderer
+      def initialize(view_context)
+        @view_context = view_context
+      end
+
+      def method_missing(method, *args, &block)
+        @view_context.render(
+          partial: "components/#{method.to_s}",
+          locals: args.first.with_indifferent_access
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Make it closer to how nunjucks works for better consistency.

Avoids having to pass component names as strings, instead treating them more like functions calls - which is the model we're trying to follow.

New Rails invocation:

```erb

<%= govuk_component.button(text: 'Start now') %>
```
#### What type of change is it?
- Breaking change (fix or feature that would cause existing functionality to change)

Any rails apps will need to update their component helper calls.
