### PR TITLE
Add wrapper for the content block

### DIFF
--- a/src/templates/govuk_template.njk
+++ b/src/templates/govuk_template.njk
@@ -58,9 +58,11 @@
 
     <div id="global-header-bar"></div>
 
-    <div id="content" class="gv-o-wrapper">
+    {% block content_wrapper %}
+    <div id="content" class="gv-o-wrapper ">
       {% block content %}{% endblock %}
     </div>
+    {% endblock %}
 
     <footer class="group js-footer" id="footer" role="contentinfo">
 

--- a/src/templates/govuk_template.njk
+++ b/src/templates/govuk_template.njk
@@ -58,7 +58,9 @@
 
     <div id="global-header-bar"></div>
 
-    {% block content %}{% endblock %}
+    <div id="content" class="gv-o-wrapper">
+      {% block content %}{% endblock %}
+    </div>
 
     <footer class="group js-footer" id="footer" role="contentinfo">
 

--- a/src/templates/unbranded_template.njk
+++ b/src/templates/unbranded_template.njk
@@ -58,7 +58,11 @@
 
     <div id="global-header-bar"></div>
 
-    {% block content %}{% endblock %}
+    {% block content_wrapper %}
+    <div id="content" class="gv-o-wrapper">
+      {% block content %}{% endblock %}
+    </div>
+    {% endblock %}
 
     <footer class="group js-footer" id="footer" role="contentinfo"></footer>
 


### PR DESCRIPTION
Add a wrapper to constrain the width of the content area.

Use the `id=“content”` here as the skiplink expects it

Use a wrapping class `.gv-o-wrapper`, to constrain the width of the page.

This has been [tested in the Node starter kit](https://github.com/alphagov/govuk-frontend-alpha-starter-kit-node/commit/55ffc5f171090f3c56c008f00bd4c6832549e328).

#### Screenshots (if appropriate):

#### Before:
![before](https://cloud.githubusercontent.com/assets/417754/22379021/89af5d92-e4af-11e6-914f-d1b6af738fb8.png)
#### After:
![after](https://cloud.githubusercontent.com/assets/417754/22379044/a00a5ccc-e4af-11e6-8f13-7f084a2a76f5.png)


#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply: -->
- New feature (non-breaking change which adds functionality)
