### PR TITLE
Use `govuk` prefix for invoking components in consumers

### DIFF
--- a/docs/using-with-node.md
+++ b/docs/using-with-node.md
@@ -103,14 +103,14 @@ You will need to ensure your stylesheet is included in the `head` block - see ab
 In your index template, add this line underneath `{% extends "layout.njk" %}` to import all components:
 
 ```nunjucks
-{% import "components.njk" as govuk_components %}
+{% import "components.njk" as govuk %}
 ```
 
 Your index template, `views/index.njk` should now look like this:
 
 ```nunjucks
 {% extends "layout.njk" %}
-{% import "components.njk" as govuk_components %}
+{% import "components.njk" as govuk %}
 ```
 
 ## Use a component in your application
@@ -122,13 +122,13 @@ Copy the Nunjucks macro to implement a component.
 Here is an example of a macro for a button component:
 
 ```nunjucks
-{{ govuk_components.button(text="Change this button text") }}
+{{ govuk.button(text="Change this button text") }}
 ```
 
 Copy and paste this macro into your index template and change the button text.
 
 ```nunjucks
-{{ govuk_components.button(text="Save and continue") }}
+{{ govuk.button(text="Save and continue") }}
 ```
 
 Go to http://localhost:3000

--- a/lib/fractal/govuk-theme/index.js
+++ b/lib/fractal/govuk-theme/index.js
@@ -76,7 +76,7 @@ customTheme.on('init', function (env, app) {
     const changeCase = require('change-case')
     const caseMethod = format === 'erb' ? 'snakeCase' : 'camelCase'
     const separator = format === 'erb' ? ': ' : ' = '
-    const componentMethod = 'govuk_components.' + changeCase[caseMethod](componentName)
+    const componentMethod = 'govuk.' + changeCase[caseMethod](componentName)
 
     var argsFormatted = []
     let argFormatted

--- a/lib/packaging/gem/lib/govuk_frontend_alpha.rb
+++ b/lib/packaging/gem/lib/govuk_frontend_alpha.rb
@@ -27,9 +27,9 @@ module GovukFrontendAlpha
   end
 
   module ApplicationHelper
-    def govuk_component
+    def govuk
       # allows components to be called like this:
-      # `govuk_component.button(text: 'Start now')`
+      # `govuk.button(text: 'Start now')`
       DynamicComponentRenderer.new(self)
     end
 

--- a/src/components/breadcrumbs/README.md
+++ b/src/components/breadcrumbs/README.md
@@ -5,7 +5,7 @@
 [Import](https://mozilla.github.io/nunjucks/templating.html#import) the components template and bind all of its exported values to a variable so that we can use it:
 
 ```nunjucks
-{% raw %}{% import "components.njk" as govuk_components %}
+{% raw %}{% import "components.njk" as govuk %}
 {% endraw %}
 ```
 
@@ -16,7 +16,7 @@ Call **breadcrumbs** like a normal function, set values for object keys `'title'
 ### Default
 
 ```nunjucks
-{% raw %}{{ govuk_components.breadcrumbs(
+{% raw %}{{ govuk.breadcrumbs(
   [
     { title: 'Home', url: '/' },
     { title: 'Section', url:'/section' }
@@ -28,7 +28,7 @@ Call **breadcrumbs** like a normal function, set values for object keys `'title'
 ### Single section
 
 ```nunjucks
-{% raw %}{{ govuk_components.breadcrumbs(
+{% raw %}{{ govuk.breadcrumbs(
   [
     { title: 'Home', url: '/' }
   ]
@@ -39,7 +39,7 @@ Call **breadcrumbs** like a normal function, set values for object keys `'title'
 ### Multiple sections
 
 ```nunjucks
-{% raw %}{{ govuk_components.breadcrumbs(
+{% raw %}{{ govuk.breadcrumbs(
   [
     { title: 'Home', url: '/' },
     { title: 'Section', url:'/section' },
@@ -53,7 +53,7 @@ Call **breadcrumbs** like a normal function, set values for object keys `'title'
 ### Last breadcrumb is current page
 
 ```nunjucks
-{% raw %}{{ govuk_components.breadcrumbs(
+{% raw %}{{ govuk.breadcrumbs(
   [
     { title: 'Home', url: '/' },
     { title: 'Section'}

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -6,7 +6,7 @@
 
 ```nunjucks
 {% raw %}
-  {% import "components.njk" as govuk_components %}
+  {% import "components.njk" as govuk %}
 {% endraw %}
 ```
 
@@ -16,7 +16,7 @@ Call **details** like a normal function, set values for arguments `'summary', 't
 
 ```nunjucks
 {% raw %}
-{{ govuk_components.details(
+{{ govuk.details(
   summary="Summary text goes in here",
   content="Details text goes in here"
 ) }}
@@ -25,7 +25,7 @@ Call **details** like a normal function, set values for arguments `'summary', 't
 
 ```nunjucks
 {% raw %}
-{{ govuk_components.details(
+{{ govuk.details(
   summary="Summary text goes in here",
   contentHtml="<p>We need to know your nationality so we can work out which elections you’re entitled to vote in.</p> <a href=\"#\">I can’t provide my nationality</a>"
 ) }}

--- a/src/components/form-checkbox-group/README.md
+++ b/src/components/form-checkbox-group/README.md
@@ -6,7 +6,7 @@
 
 ```nunjucks
 {% raw %}
-  {% import "components.njk" as govuk_components %}
+  {% import "components.njk" as govuk %}
 {% endraw %}
 ```
 
@@ -17,7 +17,7 @@ Call **formCheckboxGroup** like a normal function, set values for arguments `'id
 ```nunjucks
 
 {% raw %}
-  {{ govuk_components.formCheckboxGroup(
+  {{ govuk.formCheckboxGroup(
     id="contact-c",
     name="contact-group",
     legend="How do you want to be contacted?",
@@ -48,7 +48,7 @@ Call **formCheckboxGroup** like a normal function, set values for arguments `'id
 
 ```nunjucks
 {% raw %}
-{{ govuk_components.formCheckboxGroup(
+{{ govuk.formCheckboxGroup(
   id="contact-d",
   name="contact-group",
   legend="How do you want to be contacted?",

--- a/src/components/form-date-group/README.md
+++ b/src/components/form-date-group/README.md
@@ -6,7 +6,7 @@
 
 ```nunjucks
 {% raw %}
-  {% import "components.njk" as govuk_components %}
+  {% import "components.njk" as govuk %}
 {% endraw %}
 ```
 
@@ -16,7 +16,7 @@ Call **formDateGroup** like a normal function, set values for arguments `'id', '
 
 ```nunjucks
 {% raw %}
-{{ govuk_components.formDateGroup(
+{{ govuk.formDateGroup(
   id="dob",
   name="dob",
   legend="What is your date of birth?",
@@ -33,7 +33,7 @@ Call **formDateGroup** like a normal function, set values for arguments `'id', '
 
 ```nunjucks
 {% raw %}
-{{ govuk_components.formDateGroup(
+{{ govuk.formDateGroup(
   id="dob",
   name="dob",
   legend="What is your date of birth?",

--- a/src/components/form-group/README.md
+++ b/src/components/form-group/README.md
@@ -6,7 +6,7 @@
 
 ```nunjucks
 {% raw %}
-  {% import "components.njk" as govuk_components %}
+  {% import "components.njk" as govuk %}
 {% endraw %}
 ```
 
@@ -16,7 +16,7 @@ Call **formGroup** like a normal function, set values for arguments `'id', 'name
 
 ```nunjucks
 {% raw %}
-{{ govuk_components.formGroup(
+{{ govuk.formGroup(
   id="nino",
   name="nino",
   label="What is your National Insurance number",
@@ -29,7 +29,7 @@ Call **formGroup** like a normal function, set values for arguments `'id', 'name
 
 ```nunjucks
 {% raw %}
-{{ govuk_components.formGroup(
+{{ govuk.formGroup(
   id="nino",
   name="nino",
   label="What is your National Insurance number",
@@ -43,7 +43,7 @@ Call **formGroup** like a normal function, set values for arguments `'id', 'name
 
 ```nunjucks
 {% raw %}
-{{ govuk_components.formGroup(
+{{ govuk.formGroup(
   id="textarea",
   name="textarea",
   label="This isthe label text",

--- a/src/components/form-radio-group/README.md
+++ b/src/components/form-radio-group/README.md
@@ -6,7 +6,7 @@
 
 ```nunjucks
 {% raw %}
-  {% import "components.njk" as govuk_components %}
+  {% import "components.njk" as govuk %}
 {% endraw %}
 ```
 
@@ -16,7 +16,7 @@ Call **formRadioGroup** like a normal function, set values for arguments `'id', 
 
 ```nunjucks
 {% raw %}
-{{ govuk_components.formRadioGroup(
+{{ govuk.formRadioGroup(
   id="contact-1a",
   name="contact-group",
   legend="How do you want to be contacted?",
@@ -46,7 +46,7 @@ Call **formRadioGroup** like a normal function, set values for arguments `'id', 
 
 ```nunjucks
 {% raw %}
-{{ govuk_components.formRadioGroup(
+{{ govuk.formRadioGroup(
   id="contact-1b",
   name="contact-group",
   legend="How do you want to be contacted?",

--- a/src/components/link-back/README.md
+++ b/src/components/link-back/README.md
@@ -6,7 +6,7 @@
 
 ```nunjucks
 {% raw %}
-  {% import "components.njk" as govuk_components %}
+  {% import "components.njk" as govuk %}
 {% endraw %}
 ```
 
@@ -16,7 +16,7 @@ Call **linkBack** like a normal function, set values for arguments `'link', 'tex
 
 ```nunjucks
 {% raw %}
-{{ govuk_components.linkBack(
+{{ govuk.linkBack(
   link="/",
   text="Back"
 ) }}

--- a/src/components/notice/README.md
+++ b/src/components/notice/README.md
@@ -6,7 +6,7 @@
 
 ```nunjucks
 {% raw %}
-  {% import "notice.njk" as govuk_components %}
+  {% import "notice.njk" as govuk %}
 {% endraw %}
 ```
 
@@ -16,7 +16,7 @@ Call **notice** like a normal function, set values for arguments `'summary', 'te
 
 ```nunjucks
 {% raw %}
-{{ govuk_components.notice(
+{{ govuk.notice(
   iconDescription="Warning",
   text="Legal text goes in here"
 ) }}

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -6,7 +6,7 @@
 
 ```nunjucks
 {% raw %}
-  {% import "components.njk" as govuk_components %}
+  {% import "components.njk" as govuk %}
 {% endraw %}
 ```
 
@@ -16,7 +16,7 @@ Call **phaseBanner** like a normal function, set values for arguments `'phase', 
 
 ```nunjucks
 {% raw %}
-{{ govuk_components.phaseBanner(
+{{ govuk.phaseBanner(
   "Beta",
   message="This service is in Beta – your feedback will help us to improve it."
 ) }}
@@ -28,7 +28,7 @@ Call **phaseBanner** like a normal function, set values for arguments `'phase', 
 
 ```nunjucks
 {% raw %}
-{{ govuk_components.phaseBanner(
+{{ govuk.phaseBanner(
   "Beta",
   messageHtml='This service is new – your <a href="#">feedback</a> will help us to improve it.'
 ) }}


### PR DESCRIPTION
We were using `govuk_components` in nunjucks/node and `govuk_component`
in erb/rails, which is confusing, especially once we're showing call
patterns in fractal.

This standardises them, but after discussion we agreed `govuk` was
simpler and shorter, so while we're changing it we'd go with that.

#### What does it do?

Change the component invocation from:
```
govuk_components.button
```

to

```
govuk.button
```

#### Screenshots (if appropriate):

#### What type of change is it?
- Breaking change

Consuming apps will need to update their component calls.
