### PR TITLE
Add a stylesheet block to allow the stylesheet to be overridden

### DIFF
--- a/src/templates/govuk_template.njk
+++ b/src/templates/govuk_template.njk
@@ -6,10 +6,9 @@
     <meta charset="utf-8" />
     <title>{% block page_title %}GOV.UK - The best place to find government services and information{% endblock %}</title>
 
-    <!--[if gt IE 8]><!--><link href="{{ asset_path + 'stylesheets/govuk-frontend.css' }}" media="screen" rel="stylesheet" /><!--<![endif]-->
-    <!--[if IE 6]><link href="{{ asset_path + 'stylesheets/govuk-template-ie6.css' }}" media="screen" rel="stylesheet" /><![endif]-->
-    <!--[if IE 7]><link href="{{ asset_path + 'stylesheets/govuk-template-ie7.css' }}" media="screen" rel="stylesheet" /><![endif]-->
-    <!--[if IE 8]><link href="{{ asset_path + 'stylesheets/govuk-template-ie8.css' }}" media="screen" rel="stylesheet" /><![endif]-->
+    {% block stylesheet %}
+    <link href="{{ asset_path + 'stylesheets/'+ govuk-frontend.css' }}" media="screen" rel="stylesheet" />
+    {% endblock %}
     <link href="{{ asset_path + 'stylesheets/govuk-template-print.css' }}" media="print" rel="stylesheet" />
 
     <!--[if lte IE 8]><script src="{{ asset_path + 'javascripts/ie-shim.js' }}"></script><![endif]-->


### PR DESCRIPTION
Add a new `stylesheet` block, remove the conditional comments and IE specific stylesheets.

Alternatively, this could be a variable, defaulting to `govuk-frontend.css` if it isn't overridden.

For now, this will ensure that consuming apps can override the compiled `govuk-frontend.css` with their own application stylesheet.





For now, this allows consuming

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply: -->
- New feature (non-breaking change which adds functionality)