### PR TITLE
Generate a tgz of the gem package

### DIFF
--- a/lib/tasks/package-gem.js
+++ b/lib/tasks/package-gem.js
@@ -11,7 +11,7 @@ const run = require('gulp-run')
 const del = require('del')
 
 gulp.task('package:gem', cb => {
-  runSequence('package:gem:prepare', 'package:gem:build', 'package:gem:copy', 'package:gem:clean', cb)
+  runSequence('package:gem:prepare', 'package:gem:build', 'package:gem:tgz', 'package:gem:copy', 'package:gem:clean', cb)
 })
 
 gulp.task('package:gem:prepare', () => {
@@ -31,6 +31,10 @@ gulp.task('package:gem:prepare', () => {
   gulp.src(`lib/packaging/gem/${packageJson.name}.gemspec`).pipe(gulp.dest(paths.gem))
   gulp.src('lib/packaging/gem/lib/govuk_frontend_alpha.rb').pipe(gulp.dest(paths.gemLib))
   return gulp.src('package.json').pipe(gulp.dest(paths.gemConfig))
+})
+
+gulp.task('package:gem:tgz', () => {
+  run(`tar -czf ${paths.pkg}${packageName}-gem.tgz -C ${paths.gem} .`).exec()
 })
 
 gulp.task('package:gem:build', () => run(`cd ${paths.gem} && gem build ${packageJson.name}.gemspec`).exec())


### PR DESCRIPTION
It's not possible to use the existing `.gem` package easily with a rails app. While in alpha, and not shipping to rubygems, we want the example consuming apps to have a managed reference to this package.

For npm we can point from package.json to a npm tgz hosted on github, but you can't load a gem like that.

This approach generates a tgz of the gem, that can be commited to a repo, as a binary file it won't show up in an editors but can be part of the repo proper, not dependant on parent paths like the rails app is now.

The idea is the rails app will have a copy of the tgz committed, and an additional build/install step which will untar into a gitignored file, so that path can be used as a dep, but not be in git history or a developers editor (assuming they have gitignore'd files hidden).

#### What does it do?

Allows a a package to be commited to a consuming rails app in a way that won't mess up the repo or a developers editor.

Already tested with a similar setup here: https://github.com/alphagov/govuk-frontend-alpha-starter-kit-rails/commit/7f2527a7e6b99c1c51ba4aa0428f926466266d2c

#### What type of change is it?
- New feature (non-breaking change which adds functionality)
