### PR TITLE
Remove the parent content_wrapper block

### DIFF
--- a/src/templates/govuk_template.njk
+++ b/src/templates/govuk_template.njk
@@ -58,11 +58,11 @@
 
     <div id="global-header-bar"></div>
 
-    {% block content_wrapper %}
-    <div id="content" class="gv-o-wrapper ">
+
+    <div id="content" class="{% block content_class %}gv-o-wrapper{% endblock %}">
       {% block content %}{% endblock %}
     </div>
-    {% endblock %}
+
 
     <footer class="group js-footer" id="footer" role="contentinfo">
 


### PR DESCRIPTION
#### What does it do?

The `content_wrapper` block was causing transpilation to fail, nested blocks are not supported.

Instead use a `content_class` block to allow the class constraining the
width of the content area to be overridden.

#### What type of change is it?
- New feature (non-breaking change which adds functionality)
