### PR TITLE
Allow assets/variable logic inside blocks in ERB

### DIFF
--- a/lib/transpilation/erb_transpiler.js
+++ b/lib/transpilation/erb_transpiler.js
@@ -10,7 +10,11 @@ const blockFor = (key, defaultContent = '') => {
   if (key === 'content') {
     // ERB needs a default yield
     return '<%= content_for?(:content) ? yield(:content) : yield %>'
+  } else if (defaultContent === '') {
+    // Use short-form if no default reuire
+    return `<%= yield(:${key}) if content_for?(:${key}) %>`
   } else {
+    // Allows default to include other nested ERB syntax
     return `<% if content_for?(:${key}) %><%= yield(:${key}) %><% else %>${defaultContent}<% end %>`
   }
 }

--- a/lib/transpilation/erb_transpiler.js
+++ b/lib/transpilation/erb_transpiler.js
@@ -11,7 +11,7 @@ const blockFor = (key, defaultContent = '') => {
     // ERB needs a default yield
     return '<%= content_for?(:content) ? yield(:content) : yield %>'
   } else {
-    return `<%= content_for?(:${key}) ? yield(:${key}) : '${defaultContent}'.html_safe %>`
+    return `<% if content_for?(:${key}) %><%= yield(:${key}) %><% else %>${defaultContent}<% end %>`
   }
 }
 const textFor = (key, defaultContent = '') => blockFor(key, defaultContent)

--- a/lib/transpilation/transpiler.js
+++ b/lib/transpilation/transpiler.js
@@ -4,37 +4,39 @@ const through = require('through2')
 const metaTemplate = require('meta-template')
 const components = require('../components')
 
-const assetPathPattern = /\{\{ asset_path \+ '(.*?)' \}\}/
-const textForPattern = /\{\{ (.*?)\|default\('(.*?)'\) \}\}/
-const blockForPattern = /\{% block (.*?) %\}(.*?)\{% endblock %\}/
-
-const transpilationPattern = new RegExp([assetPathPattern.source, textForPattern.source, blockForPattern.source].join('|'), 'g')
-
 const transpileTemplate = (target, assetVersion) => {
+  const transpilationPatterns = [
+    {
+      name: 'assetPath',
+      pattern: /\{\{ asset_path \+ '(.*?)' \}\}/g,
+      replacer: (transpiler, asset) => transpiler.assetPath(asset, assetVersion)
+    },
+    {
+      name: 'textFor',
+      pattern: /\{\{ (.*?)\|default\('(.*?)'\) \}\}/g,
+      replacer: (transpiler, key, defaultContent) => transpiler.textFor(key, defaultContent)
+    },
+    {
+      name: 'blockFor',
+      pattern: /\{% block (.*?) %\}(.*?)\{% endblock %\}/g,
+      replacer: (transpiler, key, defaultContent) => transpiler.blockFor(key, defaultContent)
+    }
+  ]
+
   return through.obj((file, encoding, callback) => {
     if (file.isNull()) return callback(null, file)
     const targetTranspiler = require(`./${target}_transpiler.js`)
     let template = file.contents.toString(encoding)
-    template = template.replace(transpilationPattern, function (match) {
-      let replacement
-      if (arguments[1] !== undefined) {
-        // asset_path pattern
-        replacement = targetTranspiler.assetPath !== undefined
-          ? targetTranspiler.assetPath(arguments[1], assetVersion)
-          : match
-      } else if (arguments[2] !== undefined) {
-        // text_for pattern
-        replacement = targetTranspiler.textFor !== undefined
-          ? targetTranspiler.textFor(arguments[2], arguments[3])
-          : match
-      } else if (arguments[4] !== undefined) {
-        // block_for pattern
-        replacement = targetTranspiler.blockFor !== undefined
-          ? targetTranspiler.blockFor(arguments[4], arguments[5])
-          : match
-      }
-      return replacement
-    })
+
+    for (let pattern of transpilationPatterns) {
+      template = template.replace(pattern.pattern, function (match, ...args) {
+        let replacement = match
+        if (targetTranspiler[pattern.name] !== undefined) {
+          replacement = pattern.replacer.call(null, targetTranspiler, ...args)
+        }
+        return replacement
+      })
+    }
 
     file.contents = new Buffer(template)
 

--- a/test/specs/transpiler_spec.js
+++ b/test/specs/transpiler_spec.js
@@ -81,7 +81,7 @@ describe('Transpilation', () => {
       transpilationTest(erbTranspiler, nunjucksTextFor, erbTextFor, done)
     })
     it('should have a correct block_for', function (done) {
-      const erbBlockFor = `<% if content_for?(:top_of_page) %><%= yield(:top_of_page) %><% else %><% end %>`
+      const erbBlockFor = `<%= yield(:top_of_page) if content_for?(:top_of_page) %>`
       transpilationTest(erbTranspiler, nunjucksBlockFor, erbBlockFor, done)
     })
     it('should have a correct block_for for the special case content block', function (done) {

--- a/test/specs/transpiler_spec.js
+++ b/test/specs/transpiler_spec.js
@@ -19,6 +19,7 @@ const nunjucksAssetPath = `<link href="{{ asset_path + 'stylesheets/govuk-templa
 const nunjucksAssetVersion = '1.0.0'
 const nunjucksTextFor = `<a href="#content" class="skiplink">{{ skip_link_message|default('Skip to main content') }}</a>`
 const nunjucksBlockFor = `{% block top_of_page %}{% endblock %}`
+const nunjucksBlockForWithAssetPath = `{% block stylesheets %}<link href="{{ asset_path + 'file.css' }}" />{% endblock %}`
 
 describe('Transpilation', () => {
   it('should return a Buffer', function (done) {
@@ -48,6 +49,10 @@ describe('Transpilation', () => {
     it('should have a correct block_for', function (done) {
       transpilationTest(nunjucksTranspiler, nunjucksBlockFor, nunjucksBlockFor, done)
     })
+    it('should have a nested correct block_for with asset path inside', function (done) {
+      const transpiledBlockForWithAssetPath = `{% block stylesheets %}<link href="{{ asset_path }}file.css?1.0.0" />{% endblock %}`
+      transpilationTest(nunjucksTranspiler, nunjucksBlockForWithAssetPath, transpiledBlockForWithAssetPath, done)
+    })
   })
 
   describe('into ERB', () => {
@@ -72,17 +77,21 @@ describe('Transpilation', () => {
       transpilationTest(erbTranspiler, nunjucksImageAssetPath, erbImageAssetPath, done)
     })
     it('should have a correct text_for', function (done) {
-      const erbTextFor = `<a href="#content" class="skiplink"><%= content_for?(:skip_link_message) ? yield(:skip_link_message) : 'Skip to main content'.html_safe %></a>`
+      const erbTextFor = `<a href="#content" class="skiplink"><% if content_for?(:skip_link_message) %><%= yield(:skip_link_message) %><% else %>Skip to main content<% end %></a>`
       transpilationTest(erbTranspiler, nunjucksTextFor, erbTextFor, done)
     })
     it('should have a correct block_for', function (done) {
-      const erbBlockFor = `<%= content_for?(:top_of_page) ? yield(:top_of_page) : ''.html_safe %>`
+      const erbBlockFor = `<% if content_for?(:top_of_page) %><%= yield(:top_of_page) %><% else %><% end %>`
       transpilationTest(erbTranspiler, nunjucksBlockFor, erbBlockFor, done)
     })
     it('should have a correct block_for for the special case content block', function (done) {
       const nunjucksContentBlockFor = `{% block content %}{% endblock %}`
       const erbContentBlockFor = `<%= content_for?(:content) ? yield(:content) : yield %>`
       transpilationTest(erbTranspiler, nunjucksContentBlockFor, erbContentBlockFor, done)
+    })
+    it('should have a nested correct block_for with asset path inside', function (done) {
+      const erbBlockForWithAssetPath = `<% if content_for?(:stylesheets) %><%= yield(:stylesheets) %><% else %><link href="<%= asset_path 'file.css?1.0.0' %>" /><% end %>`
+      transpilationTest(erbTranspiler, nunjucksBlockForWithAssetPath, erbBlockForWithAssetPath, done)
     })
   })
 


### PR DESCRIPTION
#### What does it do?
Changes the way the `Transpiler` applies it's regex matches to convert layout templates to other outputs, to support different matchers inside of each other. 

Allow ERB `blockFor` output to include ERB logic. Previously it only allowed string content, not it can include ERB blocks.

#### What type of change is it?
- New feature (non-breaking change which adds functionality)
