### PR TITLE
Fix broken asset path in govuk_template layout

### DIFF
--- a/src/templates/govuk_template.njk
+++ b/src/templates/govuk_template.njk
@@ -6,9 +6,7 @@
     <meta charset="utf-8" />
     <title>{% block page_title %}GOV.UK - The best place to find government services and information{% endblock %}</title>
 
-    {% block stylesheet %}
-    <link href="{{ asset_path + 'stylesheets/'+ govuk-frontend.css' }}" media="screen" rel="stylesheet" />
-    {% endblock %}
+    {% block stylesheet %}<link href="{{ asset_path + 'stylesheets/govuk-frontend.css' }}" media="screen" rel="stylesheet" />{% endblock %}
     <link href="{{ asset_path + 'stylesheets/govuk-template-print.css' }}" media="print" rel="stylesheet" />
 
     <!--[if lte IE 8]><script src="{{ asset_path + 'javascripts/ie-shim.js' }}"></script><![endif]-->


### PR DESCRIPTION
The default stylesheet block's asset path is a malformed string,
which was causing the ERB transpiled output to blow up in a rails
consumer.

I'd have expected a syntax error would have blown up in nunjucks too.
It's something we can add integration tests for in the future i think.

- Bug fix (non-breaking change which fixes an issue)
