### PR TITLE
Improvements to Fractal browser panel UX

### DIFF
--- a/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
+++ b/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
@@ -172,13 +172,13 @@ a:active {
   padding: 0;
 }
 
-.Browser-panel .Code {
-  background: #fff;
-  width: 100%;
+.Browser-panel code {
+  user-select: all;
 }
 
-.Browser-panel .Code pre {
-  background: #fff;
+.Browser-panel code pre {
+  width: 100%;
+  padding: 1em;
 }
 
 /*

--- a/lib/fractal/govuk-theme/views/partials/browser/panel-nunjucks.nunj
+++ b/lib/fractal/govuk-theme/views/partials/browser/panel-nunjucks.nunj
@@ -2,9 +2,8 @@
 
 <div class="Browser-panel Browser-code Browser-nunjucks" data-role="tab-panel" id="browser-{{ entity.id }}-panel-nunjucks">
   <div class="Prose" style="width: 100%">
-    <h3>To call this component using Nunjucks:</h3>
-    <code class="Code Code--lang-njk">
-      <pre style="margin: 0; padding: .5em 1.5em; background: #f6f6f6" contenteditable >{{ "{{ " + (entity.getResolvedContext() | async | generateComponentInvocation('njk', compHandle)) + " }}" | highlight('js') }}</pre>
+    <code>
+      <pre>{{ ("{{ " + (entity.getResolvedContext() | async | generateComponentInvocation('njk', compHandle)) + " }}") | highlight('javascript') }}</pre>
     </code>
   </div>
 </div>

--- a/lib/fractal/govuk-theme/views/partials/browser/panel-ruby.nunj
+++ b/lib/fractal/govuk-theme/views/partials/browser/panel-ruby.nunj
@@ -2,10 +2,8 @@
 
 <div class="Browser-panel Browser-code Browser-ruby" data-role="tab-panel" id="browser-{{ entity.id }}-panel-ruby">
   <div class="Prose" style="width: 100%">
-    <h3>To call this component in Rails:</h3>
-
-    <code class="Code Code--lang-erb">
-      <pre style="margin: 0; padding: .5em 1.5em; background: #f6f6f6" contenteditable>{{ '<%= ' + (entity.getResolvedContext() | async | generateComponentInvocation('erb', compHandle)) + " %> " | highlight('erb') }}</pre>
+    <code>
+      <pre>{{ ('<%= ' + (entity.getResolvedContext() | async | generateComponentInvocation('erb', compHandle)) + " %> ") | highlight('erb') }}</pre>
     </code>
   </div>
 


### PR DESCRIPTION
- Use `user-select` rather than contenteditable, which made people think
  editing would live update
- Fix the syntax highlighting for JS and erb output
- Remove inline styles and use same code styling as we do in doc bocks,
  which is much more readable

#### Screenshots (if appropriate):
![screen shot 2017-02-02 at 17 52 08](https://cloud.githubusercontent.com/assets/63201/22561502/667389aa-e970-11e6-9b1c-5b2254ba256c.png)

#### What type of change is it?
- Documentation change.