### PR TITLE
Shorten NPM install instructions

### DIFF
--- a/src/docs/02-using-with-node.md
+++ b/src/docs/02-using-with-node.md
@@ -2,9 +2,11 @@
 
 ## Add govuk_frontend_alpha to your application
 
-The package is not available on the NPM registry.
+```bash
+npm install govuk_frontend_alpha --save
+```
 
-You will need to manually include it as a dependency.
+> ❗️ __Alpha Note:__ *`govuk_frontend_alpha` isn't available on the NPM registry. You'll need to install it manually (see below).*
 
 ## Amend package.json
 
@@ -15,8 +17,6 @@ Add this line to your dependencies in `package.json`:
 ```
 
 ## Install the govuk_frontend_alpha dependency
-
-If you're using [NPM](https://www.npmjs.com/):
 
 ```bash
 npm install


### PR DESCRIPTION
Add npm install instructions:
- how you will be able to install the package in future
- how you will need to manually install the package during the alpha

```
npm install govuk_frontend_alpha --save ...
``` 

#### Screenshots (if appropriate):
![using with node gov uk frontend alpha](https://cloud.githubusercontent.com/assets/417754/22588538/2c7a6dfc-e9fe-11e6-8ec4-420f07aa5959.png)



