### PR TITLE
Update docs to match changes to the node starter kit app

### DIFF
--- a/src/docs/02-using-with-node.md
+++ b/src/docs/02-using-with-node.md
@@ -26,6 +26,8 @@ npm install
 
 Create a file `index.njk` in `views`, use this file to extend the GOV.UK template.
 
+You can find the GOV.UK template in `/node_modules/govuk_frontend_alpha/templates/`.
+
 In `views/index.njk` add:
 
 ```nunjucks

--- a/src/docs/02-using-with-node.md
+++ b/src/docs/02-using-with-node.md
@@ -24,18 +24,15 @@ npm install
 
 ## Use the GOV.UK layout
 
-Create a file `layout.njk` in `views`, use this file to extend the GOV.UK template.
+Create a file `index.njk` in `views`, use this file to extend the GOV.UK template.
 
-In `views/layout.njk` add:
+In `views/index.njk` add:
 
 ```nunjucks
 {% raw %}
 {% extends "govuk_template.njk" %}
 {% endraw %}
 ```
-
-If you are using the starter application, this layout file is created already. 
-Replace the text **'Layout template'** with the above.
 
 Start your app using `npm start`
 
@@ -69,7 +66,7 @@ GOV.UK Frontend has [template blocks](/docs/template-blocks) that you can use to
 
 First, you'll need to add a stylesheet block:
 
-To set a `stylesheet` block, in `layout.njk` add:
+To set a `stylesheet` block, in `index.njk` add:
 
 
 ```nunjucks
@@ -127,7 +124,7 @@ Fix this by configuring includePaths for gulp-sass, in your gulpfile.js:
 
 ## Before using a component
 
-In your index template, add this line underneath `{% raw %}{% extends "layout.njk" %}{% endraw %}` to import all components:
+In your index template, add this line underneath `{% raw %}{% extends "govuk_template.njk" %}{% endraw %}` to import all components:
 
 ```nunjucks
 {% raw %}
@@ -139,7 +136,7 @@ Your index template, `views/index.njk` should now look like this:
 
 ```nunjucks
 {% raw %}
-{% extends "layout.njk" %}
+{% extends "govuk_template.njk" %}
 {% import "components.njk" as govuk %}
 {% endraw %}
 ```


### PR DESCRIPTION
The starter kit application has removed layout.njk in favour of a single index.njk template, update the docs to reflect this.