### PR TITLE
Documentation for amends to starter kit app

### DIFF
--- a/src/docs/02-using-with-node.md
+++ b/src/docs/02-using-with-node.md
@@ -149,6 +149,14 @@ Your index template, `views/index.njk` should now look like this:
 {% endraw %}
 ```
 
+You'll need to configure your application to find the components.
+
+In server.js, add this line to your application's views:
+
+```
+path.join(__dirname, '/node_modules/govuk_frontend_alpha/components/')
+```
+
 ## Use a component in your application
 
 [You can find all the components here](http://govuk-frontend-alpha.herokuapp.com/).

--- a/src/docs/02-using-with-node.md
+++ b/src/docs/02-using-with-node.md
@@ -70,6 +70,17 @@ GOV.UK Frontend has [template blocks](/docs/template-blocks) that you can use to
 {% endraw %}
 ```
 
+## Configure paths for static assets
+
+You'll need to configure the paths to static assets, to server the the govuk_frontend_alpha assets from the node_modules directory.
+
+In server.js add:
+
+```
+app.use('/public', express.static(path.join(__dirname, '/node_modules/govuk_frontend_alpha/assets/')))
+app.use('/images/template', express.static(path.join(__dirname, '/node_modules/govuk_frontend_alpha/assets/images/template/')))
+```
+
 ## Importing the govuk-frontend SCSS files
 
 First, you'll need to add a stylesheet block:

--- a/src/docs/02-using-with-node.md
+++ b/src/docs/02-using-with-node.md
@@ -34,8 +34,13 @@ In `views/layout.njk` add:
 {% endraw %}
 ```
 
-If you are using the starter application, this layout file is created already. 
-Replace the text **'Layout template'** with the above.
+You'll need to configure your application to find this template.
+
+In server.js, add this line to your application's views:
+
+```
+path.join(__dirname, '/node_modules/govuk_frontend_alpha/templates/')
+```
 
 Start your app using `npm start`
 


### PR DESCRIPTION
In the starter kit application, the [config for the frontend_alpha package - setting paths to templates, components and assets - has been removed](https://github.com/alphagov/govuk-frontend-alpha-starter-kit-node/pull/12).

Update the documentation to reflect how to add this. 