### PR TITLE
Make documentation code blocks easier to copy from

### DIFF
--- a/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
+++ b/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
@@ -228,6 +228,7 @@ a:active {
   code pre {
     padding: 1rem 1.5rem;
     margin: 1rem 0 1.5rem 0;
+    user-select: all;
   }
 
   blockquote {


### PR DESCRIPTION
We're already doing this on the browser code tabs, apply the same to
docs, as we expect people following install instructions to copy
frequently.

