### PR TITLE
Add mocha as a dependency, to get it's mocha 'bin'

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jasmine-spec-reporter": "^2.7.0",
     "jquery": "^3.1.1",
     "meta-template": "https://github.com/dsingleton/meta-template/tarball/default-filter",
+    "mocha": "^3.2.0",
     "nunjucks": "^2.5.2",
     "phantomjs-prebuilt": "^2.1.13",
     "rollup-stream": "^1.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3466,7 +3466,7 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   dependencies:
     minimist "0.0.8"
 
-mocha@^3.0.0:
+mocha@^3.0.0, mocha@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.2.0.tgz#7dc4f45e5088075171a68896814e6ae9eb7a85e3"
   dependencies:
@@ -4724,11 +4724,11 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
-"semver@2.x || 3.x || 4 || 5", semver@^4.1.0:
+semver@^4.1.0:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
 


### PR DESCRIPTION
This allows you to run mocha without it being globally installed, eg on the command line as `node_modules/.bin/mocha` or `npm-run mocha`, which are really useful for for running isolated tests cases, not the entire gulp-mocha suit.

This is also handy editor integrations that run mocha within a project, like: https://atom.io/packages/mocha-test-runner

(We were getting `mocha` as depdency of `gulp-mocha`, but this won't install the `mocha` binary into `node_modules/.bin`)


#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply: -->
- New feature (non-breaking change which adds functionality)
