### PR TITLE
Automatically load Rails component helper in Gem

### DIFF
--- a/lib/packaging/gem/lib/govuk_frontend_alpha.rb
+++ b/lib/packaging/gem/lib/govuk_frontend_alpha.rb
@@ -25,25 +25,29 @@ module GovukFrontendAlpha
       )
     end
   end
+end
 
-  module ApplicationHelper
-    def govuk
-      # allows components to be called like this:
-      # `govuk.button(text: 'Start now')`
-      DynamicComponentRenderer.new(self)
+# Monkey patch the `govuk` helper into all views, to avoid users having to
+# manually load the engine helper in their own ApplicationHelper
+# @TODO: Reconsider loading approach after Alpha. Could be explicit like:
+#  `helper GovukFrontendAlpha::ComponentHelper`, or just cleaner magic
+module ApplicationHelper
+  def govuk
+    # allows components to be called like this:
+    # `govuk.button(text: 'Start now')`
+    DynamicComponentRenderer.new(self)
+  end
+
+  class DynamicComponentRenderer
+    def initialize(view_context)
+      @view_context = view_context
     end
 
-    class DynamicComponentRenderer
-      def initialize(view_context)
-        @view_context = view_context
-      end
-
-      def method_missing(method, *args, &block)
-        @view_context.render(
-          partial: "components/#{method.to_s}",
-          locals: args.first.with_indifferent_access
-        )
-      end
+    def method_missing(method, *args, &block)
+      @view_context.render(
+        partial: "components/#{method.to_s}",
+        locals: args.first.with_indifferent_access
+      )
     end
   end
 end


### PR DESCRIPTION
So a consuming rails app can call `govuk.button(...)` or similar
in a view without having to load the helper explicitly. Simplifies
the install process for a rails user.

Not sure this is a good long term approach, or that it's an idiomatic
rails/engine approach, but it works for alpha/testing. Should consult
a rubiest in the future and re-consider the technical implementation.

That said, not having to do anything as a consuming app, other than call
the helper feels like a nice experience, might be _too_ magic, but
hopefully that'll show up in testing.


#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply: -->
- Bug fix (non-breaking change which fixes an issue)
