### PR TITLE
Fix image path conflicts between different consumers

### DIFF
--- a/src/assets/scss/govuk-frontend.scss
+++ b/src/assets/scss/govuk-frontend.scss
@@ -1,7 +1,3 @@
-// Path to assets for use with the file-url function
-// in the tools/url-helpers partial
-$path: "/images/";
-
 @import "settings";
 @import "tools";
 @import "generic";

--- a/src/assets/scss/settings/_global.scss
+++ b/src/assets/scss/settings/_global.scss
@@ -40,6 +40,8 @@ $mobile-ie6:          true !default;
 // URL helpers - file path
 // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_url-helpers.scss#L3
 $path:                false !default;
+// New construct
+$default-image-path: "/images/";
 
 // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_font_stack.scss
 //  GOV.UK font stacks, referred to in typography.scss

--- a/src/assets/scss/tools/_url-helpers.scss
+++ b/src/assets/scss/tools/_url-helpers.scss
@@ -7,9 +7,14 @@
 @function file-url($file) {
   $url: "";
   @if $path {
+    // Explicitly set by code importing govuk-frontend, always respect `$path`
     $url: url($path + $file);
-  } @else {
+  } @else if function-exists(image-url) {
+    // Defer to `image-url` in enviroments where it exists (`rails`, `compass`)
     $url: image-url($file);
+  } @else {
+    // Default works only with this repo, or projects with identical asset paths
+    $url: url($default-image-path + $file);
   }
   @return $url;
 }


### PR DESCRIPTION
When `$path` is always set it breaks image urls in consumers expecting
`image-url` to work, eg, rails.

Refactor the `$path` detection logic to work with all our use cases
 - Fractal (gets `$default-image-path`
 - Rails apps (uses `image-url`)
 - Node apps (continue setting their own `$path` before importing govuk-frontend
   SCSS into their own main stylesheet - or using default compiled CSS file
   and using the same static asset structure as the default path)
 - Static apps (continue using compiled CSS, assuming the asset structure matches)

Cleanup:
- Move image logic out of `govuk-frontend.scss`, as the main entry point
  to our SCSS simpler is better.
- Put all the "which image method to use" logic in one place, the mixin, and
  treat everything else as configuration, i think thats more readable.
- Move the default image path into a variable and into settings, feels better.

<!--- Provide a summary of your changes in the Title above -->

#### What does it do?

Fixes the default styling of the Rails app, so that images linked from `govuk-frontend.scss` follow the rails asset path conventions. Without breaking image paths in our other apps.

- Bug fix (non-breaking change which fixes an issue)