### PR TITLE
Hide status circles in left hand navigation

### DIFF
--- a/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
+++ b/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
@@ -250,3 +250,12 @@ a:active {
     margin-right: 5px;
   }
 }
+
+/*
+  Status
+------------------------------ */
+
+// Hide status dots in navigation
+.Status-dot {
+  display: none;
+}


### PR DESCRIPTION
#### What does it do?

All components are marked WIP, hide the corresponding status dot from
the left hand navigation.

#### Before:

![before](https://cloud.githubusercontent.com/assets/417754/22698030/3dc287e8-ed4b-11e6-8c28-f9678689aa61.png)

#### After:

![after](https://cloud.githubusercontent.com/assets/417754/22698018/37f5b786-ed4b-11e6-8a4c-df73b596413c.png)

