### PR TITLE
Create a button--start variant

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -171,23 +171,21 @@
   outline: none;
 }
 
-
-// TODO: Think of sensible names for button modifiers
-.gv-c-button--get-started {
+.gv-c-button--start {
   @include bold-24;
 
   padding: em(7) em(41) em(4) em(16);
 
-  background-image: file-url("icon-pointer.png");
+  background-image: file-url("toolkit/icon-pointer.png");
   background-repeat: no-repeat;
   background-position: 100% 50%;
 
   @include device-pixel-ratio {
-    background-image: file-url("icon-pointer-2x.png");
+    background-image: file-url("toolkit/icon-pointer-2x.png");
     background-size: 30px 19px;
   }
 
   @include ie(6) {
-    background-image: file-url("icon-pointer-2x.png");
+    background-image: file-url("toolkit/icon-pointer-2x.png");
   }
 }

--- a/src/components/button/button.config.js
+++ b/src/components/button/button.config.js
@@ -5,11 +5,11 @@ module.exports = {
     text: 'Default button text'
   },
   variants: [{
-    name: 'primary',
+    name: 'start',
     context: {
-      isPrimary: true,
-      text: 'Primary button text'
+      isStart: true,
+      text: 'Start now'
     }
   }],
-  arguments: ['text', 'type', 'isPrimary']
+  arguments: ['text', 'type', 'isStart']
 }

--- a/src/components/button/button.njk
+++ b/src/components/button/button.njk
@@ -1,3 +1,3 @@
-<button class="gv-c-button {% if isPrimary %}gv-c-button--primary{% endif %}">
+<button class="gv-c-button {% if isStart %}gv-c-button--start{% endif %}">
   {% if text %}{{ text }}{% endif %}
 </button>

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -11,12 +11,12 @@ describe('Button component', () => {
     )
   })
 
-  it('should render primary', function () {
+  it('should render a start button', function () {
     expectComponent(
       'button',
-      { text: 'hello!', isPrimary: true },
-      `<button class="gv-c-button gv-c-button--primary">
-        hello!
+      { text: 'Start now', isStart: true },
+      `<button class="gv-c-button gv-c-button--start">
+        Start now
       </button>`
     )
   })


### PR DESCRIPTION
#### What does it do?

- Rename button--get-started to button--start
- Update the paths to images assets for the arrow image (these are in images/toolkit)
- Replace the isPrimary button variant with an isStart variant
- Update the component to apply the correct modifier class

#### Screenshots (if appropriate):

#### Before:

![before - button primary](https://cloud.githubusercontent.com/assets/417754/22698790/7307a292-ed4d-11e6-82c3-1499034e5fa3.png)

#### After:

![after - button start](https://cloud.githubusercontent.com/assets/417754/22698794/76758a20-ed4d-11e6-91ea-6bdd20838dd4.png)







