### PR TITLE
Keep 'package.json' and 'yarn.lock' in sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - 6.6.0
 sudo: false
 script:
-- yarn test
+- yarn test && yarn check --integrity
 notifications:
   email: false
 deploy:


### PR DESCRIPTION
If a dependency is added to `package.json`, or a versioned bumped,
without `yarn.lock` having been updated this will cause Travis tests
to fail and prevent things getting out of sync in an automated way.

https://yarnpkg.com/lang/en/docs/cli/check/
