### PR TITLE
Keep 'package.json' and 'yarn.lock' in sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
 - 6.6.0
 sudo: false
 script:
+# Ensures `package.json` and `yarn.lock` stay in sync
+- yarn check --integrity
 - yarn test
 notifications:
   email: false


### PR DESCRIPTION
If a dependency is added to `package.json`, or a versioned bumped,
without `yarn.lock` having been updated this will cause Travis tests
to fail and prevent things getting out of sync in an automated way.

https://yarnpkg.com/lang/en/docs/cli/check/

Supersedes #198. 

I tried putting `yarn check` as an `install:` step in `.travis.yml`, but when that ran `yarn` wasn't installed. I'm not sure if this is a run-order issue, or something to do how [yarn vs npm works in travis](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Travis-CI-supports-yarn).

In the mean time, splitting the command over two lines and adding a comment feels much more readable than the original PR.