### PR TITLE
Add block variable for body attributes

### DIFF
--- a/src/templates/govuk_template.njk
+++ b/src/templates/govuk_template.njk
@@ -24,7 +24,7 @@
     {% block head %}{% endblock %}
   </head>
 
-  <body class="{% block body_classes %}{% endblock %}">
+  <body class="{% block body_classes %}{% endblock %}" {% block body_attributes %}{% endblock %}>
     <!--[if gte IE 8]><!--><script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script></script><!--<![endif]-->
 
     {% block body_start %}{% endblock %}


### PR DESCRIPTION
#### What does it do?
I've inheritied a project which relies on GA event tagging being driven by attributes dynamically added to the body tag.
Would you accept a modification which allows for a block variable being added to the body tag? This should be a non-breaking change for anyone not using this block var.

#### What type of change is it?
- New feature (non-breaking change which adds functionality)
