### PR TITLE
Add Google-hosted jQuery to the template

### DIFF
--- a/src/templates/govuk_template.njk
+++ b/src/templates/govuk_template.njk
@@ -88,6 +88,7 @@
     <div id="global-app-error" class="app-error hidden"></div>
 
     <!--[if gte IE 8]><!-->
+      <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
       <script src="{{ asset_path + 'javascripts/govuk-template.min.js' }}"></script>
       <script src="{{ asset_path + 'javascripts/toolkit.min.js' }}"></script>
       <script src="{{ asset_path + 'javascripts/components.min.js' }}"></script>


### PR DESCRIPTION
The toolkit.min.js file expects jQuery to be available and without it, an error is shown in the console.
"Uncaught TypeError: $ is not a function".

Adding jQuery fixes this, and #143.

This has been tested in the node starter kit application.


