### PR TITLE
Use relative URLs in image paths, for consistency

### DIFF
--- a/config/paths.json
+++ b/config/paths.json
@@ -11,7 +11,7 @@
   "dist": "dist/",
   "distFractal": "dist/fractal/",
   "bundle": "dist/bundle/",
-  "bundleImg": "dist/bundle/assets/img/",
+  "bundleImg": "dist/bundle/assets/images/",
   "bundleCss": "dist/bundle/assets/css/",
   "bundleScss": "dist/bundle/assets/scss/",
   "bundleJs": "dist/bundle/assets/js/",

--- a/src/assets/scss/settings/_global.scss
+++ b/src/assets/scss/settings/_global.scss
@@ -41,7 +41,7 @@ $mobile-ie6:          true !default;
 // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_url-helpers.scss#L3
 $path:                false !default;
 // New construct
-$default-image-path: "/images/";
+$default-image-path: "../images/";
 
 // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_font_stack.scss
 //  GOV.UK font stacks, referred to in typography.scss


### PR DESCRIPTION
In static CSS output (eg, in bundle) this makes the paths work without
having to have assets at the root dir, they can be relative to the
CSS file include the images.

Requires making the bundle images dir consistent with the expectation
in the SCSS image includes.

Previously the bundle images directory was `img`, but our default `$path` is the `images` dir, so that path has never worked from the bundled CSS.

#### What does it do?

Makes background images work in the static CSS build by default.
