### PR TITLE
Remove empty string arguments from component variants

### DIFF
--- a/src/components/form-checkbox-group/form-checkbox-group.config.js
+++ b/src/components/form-checkbox-group/form-checkbox-group.config.js
@@ -6,8 +6,6 @@ module.exports = {
     name: 'contact-group',
     legend: 'How do you want to be contacted?',
     legendIsVisuallyHidden: false,
-    hint: '',
-    error: '',
     checkboxGroup: [{
       id: 'example-contact-by-email',
       value: 'contact-by-email',

--- a/src/components/form-date-group/form-date-group.config.js
+++ b/src/components/form-date-group/form-date-group.config.js
@@ -5,25 +5,20 @@ module.exports = {
     id: 'dob',
     name: 'dob-group',
     legend: 'What is your date of birth?',
-    hint: '',
-    error: '',
     day: {
       id: 'dob-day',
-      value: '',
       label: 'Day',
       min: '0',
       max: '31'
     },
     month: {
       id: 'dob-month',
-      value: '',
       label: 'Month',
       min: '0',
       max: '12'
     },
     year: {
       id: 'dob-year',
-      value: '',
       label: 'Year',
       min: '0',
       max: '2050'

--- a/src/components/form-group/form-group.config.js
+++ b/src/components/form-group/form-group.config.js
@@ -4,10 +4,7 @@ module.exports = {
   context: {
     id: 'full-name',
     name: 'full-name',
-    label: 'Full name',
-    hint: '',
-    error: '',
-    value: ''
+    label: 'Full name'
   },
   variants: [{
     name: 'has hint',

--- a/src/components/form-group/form-group.njk
+++ b/src/components/form-group/form-group.njk
@@ -9,7 +9,7 @@
     {% endif %}
   </label>
   {% if isTextarea %}
-    <textarea class="gv-c-form-group__control {% if error %}gv-c-form-group__control--has-error{% endif %}" id="{{ id }}" name="{{ name }}" cols="30" rows="5">{{ value}}</textarea>
+    <textarea class="gv-c-form-group__control {% if error %}gv-c-form-group__control--has-error{% endif %}" id="{{ id }}" name="{{ name }}" cols="30" rows="5">{{ value }}</textarea>
   {% endif %}
   {% if not isTextarea %}
     <input class="gv-c-form-group__control {% if error %}gv-c-form-group__control--has-error{% endif %}" id="{{ id }}" name="{{ name }}" value="{{ value }}" type="text">

--- a/src/components/form-radio-group/form-radio-group.config.js
+++ b/src/components/form-radio-group/form-radio-group.config.js
@@ -6,8 +6,6 @@ module.exports = {
     name: 'contact-group',
     legend: 'How do you want to be contacted?',
     legendIsVisuallyHidden: false,
-    hint: '',
-    error: '',
     radioGroup: [{
       id: 'example-contact-by-email',
       value: 'contact-by-email',


### PR DESCRIPTION
1. In rails this was causing rendering errors, eg, an empty string
   of `error`, eg `error => ''` is treated as true in ruby, and was
   causing the default form-group component to render as an error
   when copied from fractal.

2. Removing empty string arguments from variants makes the examples
   simpler and easier to understand / reason about.