### PR TITLE
Set explicit rollup format to avoid warnings

### DIFF
--- a/lib/tasks/build-scripts.js
+++ b/lib/tasks/build-scripts.js
@@ -15,7 +15,8 @@ const uglifySaveLicense = require('uglify-save-license')
 let scriptsBuilder = fileName => {
   return rollup({
     entry: paths.assetsJs + fileName + '.manifest.js',
-    context: 'window'
+    context: 'window',
+    format: 'es'
   })
     .pipe(vinylSource(fileName + '.js'))
     .pipe(gulp.dest(paths.bundleJs))


### PR DESCRIPTION
Warnings were appearing in gulp output. Previously defaulted to `es`,
specifying it avoids the warning.

https://github.com/rollup/rollup/wiki/JavaScript-API#format
