### PR TITLE
Make fractal browser tabs render code consistently

### DIFF
--- a/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
+++ b/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
@@ -171,10 +171,11 @@ a:active {
   background: #fff;
   padding: 0;
 }
-
-.Browser-panel code pre {
+.Browser-panel .Code {
   width: 100%;
-  padding: 1em;
+}
+.Browser-panel .Code pre {
+  padding: 1rem 1.5rem;
 }
 
 /*

--- a/lib/fractal/govuk-theme/views/partials/browser/panel-nunjucks.nunj
+++ b/lib/fractal/govuk-theme/views/partials/browser/panel-nunjucks.nunj
@@ -1,9 +1,7 @@
 {% set compHandle = entity.component().handle %}
 
 <div class="Browser-panel Browser-code Browser-nunjucks" data-role="tab-panel" id="browser-{{ entity.id }}-panel-nunjucks">
-  <div class="Prose" style="width: 100%">
-    <code>
-      <pre>{{ ("{{ " + (entity.getResolvedContext() | async | generateComponentInvocation('njk', compHandle)) + " }}") | highlight('javascript') }}</pre>
-    </code>
-  </div>
+  <code class="Code">
+    <pre>{{ ("{{ " + (entity.getResolvedContext() | async | generateComponentInvocation('njk', compHandle)) + " }}") | highlight('javascript') }}</pre>
+  </code>
 </div>

--- a/lib/fractal/govuk-theme/views/partials/browser/panel-ruby.nunj
+++ b/lib/fractal/govuk-theme/views/partials/browser/panel-ruby.nunj
@@ -1,11 +1,7 @@
 {% set compHandle = entity.component().handle %}
 
 <div class="Browser-panel Browser-code Browser-ruby" data-role="tab-panel" id="browser-{{ entity.id }}-panel-ruby">
-  <div class="Prose" style="width: 100%">
-    <code>
-      <pre>{{ ('<%= ' + (entity.getResolvedContext() | async | generateComponentInvocation('erb', compHandle)) + " %> ") | highlight('erb') }}</pre>
-    </code>
-  </div>
-
-
+  <code class="Code">
+    <pre>{{ ('<%= ' + (entity.getResolvedContext() | async | generateComponentInvocation('erb', compHandle)) + " %> ") | highlight('erb') }}</pre>
+  </code>
 </div>


### PR DESCRIPTION
The html/context tabs were rendering differently to the ruby/nunjucks
ones. This standardises the behaviour.