### PR TITLE
Update Fractal design

### DIFF
--- a/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
+++ b/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
@@ -292,7 +292,7 @@ a:active {
 
 .Frame {
   position: relative;
-  height: auto;
+  height: inherit;
   overflow: auto;
 }
 
@@ -304,4 +304,9 @@ a:active {
 
 .Pen-panel .Browser{
   position: relative;
+}
+
+.Frame-header {
+  position: sticky;
+  top: 0px;
 }

--- a/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
+++ b/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
@@ -14,7 +14,7 @@ a:visited {
 }
 
 a:hover {
-  color: $link-hover-colour;
+  text-decoration: underline;
 }
 
 a:active {
@@ -28,6 +28,7 @@ a:active {
 // Sidebar background
 .Frame-panel--sidebar {
   background: $white;
+  width: 310px;
 }
 
 // Left hand navigation
@@ -43,8 +44,9 @@ a:active {
   color: $text-colour;
   text-transform: none;
   @include bold-19;
-  margin-top: 0.5em;
-  margin-bottom: 0.75em;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  margin: 0;
 }
 
 // Component name
@@ -62,8 +64,8 @@ a:active {
 // Left hand navigation item
 .Tree-entityLink {
   @include core-16;
-  padding-top: 0.5rem;
-  padding-bottom: 0.4rem;
+  padding-top: 8px;
+  padding-bottom: 8px;
 }
 
 .Tree-entityLink:hover {
@@ -74,6 +76,33 @@ a:active {
 .is-current .Tree-entityLink {
   color: $white;
   background: $govuk-blue;
+}
+
+[dir="ltr"] .Tree-title {
+  padding-left: 30px;
+}
+[dir="ltr"] .Tree-title,
+[dir="ltr"] .Tree-depth-1 .Tree-entityLink,
+[dir="ltr"] .Tree-depth-1 .Tree-collectionLabel,
+[dir="ltr"] .Tree-depth-2 .Tree-collectionLabel {
+  padding-left: 30px;
+}
+
+[dir="ltr"] .Tree-depth-2 .Tree-collectionLabel span {
+  margin-left: 0;
+}
+
+[dir="ltr"] .Tree-depth-2 .Tree-entityLink {
+  padding-left: 45px;
+}
+
+[dir="ltr"] .Tree-collectionLabel span {
+  padding-left: 0;
+  color: $link-colour;
+}
+
+.Tree-collectionLabel span::before {
+  display: none;
 }
 
 /*

--- a/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
+++ b/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
@@ -255,3 +255,24 @@ a:active {
 .Status-dot {
   display: none;
 }
+
+
+/*
+  Panel scrolling - disabled
+------------------------------ */
+
+.Frame {
+  position: relative;
+  height: auto;
+  overflow: auto;
+}
+
+.Frame-inner {
+  position: relative;
+  height: auto;
+  overflow: auto;
+}
+
+.Pen-panel .Browser{
+  position: relative;
+}

--- a/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
+++ b/lib/fractal/govuk-theme/assets/scss/_theme-overrides.scss
@@ -113,11 +113,6 @@ a:active {
   margin: 15px 20px;
 }
 
-// Component boxes
-.Pen-panel {
-  margin-bottom: 15px;
-}
-
 // Component title and status wrapper
 .Pen-header {
   max-height: 4rem;
@@ -163,14 +158,6 @@ a:active {
 ------------------------------ */
 
 // Component info box
-.Pen-info {
-  border-color: $white;
-}
-
-.Browser-controls {
-  margin-bottom: 30px;
-}
-
 .Browser-tab a:link,
 .Browser-tab a:visited,
 .Browser-tab a:hover,

--- a/lib/fractal/govuk-theme/views/partials/header.nunj
+++ b/lib/fractal/govuk-theme/views/partials/header.nunj
@@ -10,13 +10,9 @@
         </span>
         <span class="header__title">
           Frontend
+          <span class="phase-banner" title="This tool is not ready for use in production">Alpha</span>
         </span>
       </a>
     </div>
   </div>
 </header>
-
-<div class="alpha-warning">
-  <span class="phase-banner">ALPHA</span>
-  This tool is a prototype and not intended for use on production services. <a href="https://github.com/alphagov/govuk_frontend_alpha">Find out more and give feedback</a>
-</div>


### PR DESCRIPTION
Best viewed as individual commits, and i'd recommending running it locally to get a sense of the new scroll behaviour, it's not obvious from the screenshot.

Removes the scrolling behaviour within the different panes in Fractal, eg the browser/preview section. Based on user research feedback.

Update the visual design to be more consistent with the tech docs format, in particular left hand nav. (fixes #211)

#### Screenshots 
![image](https://cloud.githubusercontent.com/assets/63201/22882476/210a59f4-f1e3-11e6-81e2-47f04cc92bbd.png)

Also reduces the spacing under component boxes and adds a border around the  component information tabs.

Before:
![before](https://cloud.githubusercontent.com/assets/417754/22884061/d3910b34-f1ea-11e6-97ed-9ccc91664d1e.png)

After:
![after](https://cloud.githubusercontent.com/assets/417754/22884059/d025a23e-f1ea-11e6-9035-2702b7df918a.png)

