### PR TITLE
Add a phase banner block

### DIFF
--- a/src/docs/04-template-blocks.md
+++ b/src/docs/04-template-blocks.md
@@ -18,6 +18,7 @@
 | inside_header             | Inside parent `.header-global`                  | Insertion point
 | proposition_header        | Inside parent `.header-wrapper`                 | Add a [propositional title and navigation links](https://github.com/alphagov/govuk_template/blob/master/docs/usage.md#propositional-title-and-navigation)
 | after_header              | After closing `</header>` element               | Insertion point
+| phase banner              | Before the main content `<div>`                 | Insertion point
 | content                   | Main content goes in here                       | Insertion point. Content must be wrapped with `id="content"` for the [skiplink to work](docs/usage.md#skip-link).
 | footer_top                | Inside parent `#footer-wrapper`                 | Insertion point
 | footer_support_links      | Inside parent `.footer-meta-inner`              | Insertion point

--- a/src/templates/govuk_template.njk
+++ b/src/templates/govuk_template.njk
@@ -55,6 +55,9 @@
 
     <div id="global-header-bar"></div>
 
+    <div class="gv-o-wrapper">
+      {% block phase_banner %}{% endblock %}
+    </div>
 
     <div id="content" class="{% block content_class %}gv-o-wrapper{% endblock %}">
       {% block content %}{% endblock %}


### PR DESCRIPTION
#### What does it do?
Adds a wrapping block for the phase banner to the GOV.UK Frontend layout template, above the content area.

Updates the template blocks documentation to detail this new block.

#### Screenshots (if appropriate):
From the node starter kit consuming application:

![phase-banner](https://cloud.githubusercontent.com/assets/417754/22896851/8ed4f468-f219-11e6-8716-0252d81266d0.png)

#### What type of change is it?
- New feature (non-breaking change which adds functionality)
