### PR TITLE
Set the preview layout to extend the govuk_template layout

### DIFF
--- a/config/paths.json
+++ b/config/paths.json
@@ -3,6 +3,7 @@
   "src": "src",
   "srcComponents": "src/components/",
   "srcScopes": "src/components/_scopes/",
+  "srcTemplates": "src/templates/",
   "srcDocs": "src/docs/",
   "assetsImg": "src/assets/images/",
   "assetsJs": "src/assets/js/",

--- a/lib/fractal/config/fractal.js
+++ b/lib/fractal/config/fractal.js
@@ -5,7 +5,12 @@ const packageJson = require('../../../package.json')
 // Create a new Fractal instance
 const fractal = require('@frctl/fractal').create()
 const govukFractalTheme = require('../govuk-theme/index.js')
-const nunjucks = require('@frctl/nunjucks')
+const nunjucks = require('@frctl/nunjucks')({
+  // Alpha-only - allow component previews in documentation
+  filters: require('../extensions').filters,
+  // specify a path for Nunjucks to search in for non-component templates
+  paths: paths.srcTemplates
+})
 
 /* Fractal project config
 ----------------------------------------------------------------------------- */
@@ -38,9 +43,7 @@ fractal.components.set('path', paths.srcComponents)
 ----------------------------------------------------------------------------- */
 
 // Load the Nunjucks template engine
-fractal.docs.engine(nunjucks({
-  filters: require('../extensions').filters
-}))
+fractal.docs.engine(nunjucks)
 
 // Set the file extension for documentation files
 fractal.docs.set('ext', '.md')

--- a/src/components/_preview/_preview-govuk-template.njk
+++ b/src/components/_preview/_preview-govuk-template.njk
@@ -1,0 +1,30 @@
+{% extends "govuk_template.njk" %}
+
+{% block page_title %}
+  {{ _target.title }} &#9670; GOV.UK Frontend Alpha
+{% endblock %}
+
+{% block stylesheet %}
+  <link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-frontend.css' | path }}">
+{% endblock %}
+
+{% block stylesheet_print %}
+  <link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-template-print.css' | path }}">
+{% endblock %}
+
+{% block logo_src %}
+  {{ '/images/template/gov.uk_logotype_crown_invert_trans.png' | path }}
+{% endblock %}
+
+{% block content %}
+  {{ yield }}
+{% endblock %}
+
+{% block scripts %}
+<!--[if gte IE 8]><!-->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+  <script src="{{ '/javascripts/govuk-template.min.js' | path }}"></script>
+  <script src="{{ '/javascripts/toolkit.min.js' | path }}"></script>
+  <script src="{{ '/javascripts/components.min.js' | path }}"></script>
+<!--<![endif]-->
+{% endblock %}

--- a/src/components/_preview/_preview.njk
+++ b/src/components/_preview/_preview.njk
@@ -12,6 +12,19 @@
   <link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-template-print.css' | path }}">
 {% endblock %}
 
+{% block header_class %} hidden {% endblock %}
+
+{% block after_header %}
+  <style>
+    html {
+      background: white;
+    }
+  </style>
+{% endblock %}
+
+{% block global_header_bar %}
+{% endblock %}
+
 {% block logo_src %}
   {{ '/images/template/gov.uk_logotype_crown_invert_trans.png' | path }}
 {% endblock %}
@@ -19,6 +32,8 @@
 {% block content %}
   {{ yield }}
 {% endblock %}
+
+{% block footer_class %} hidden {% endblock %}
 
 {% block scripts %}
 <!--[if gte IE 8]><!-->

--- a/src/components/_preview/_preview.njk
+++ b/src/components/_preview/_preview.njk
@@ -8,6 +8,10 @@
   <link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-frontend.css' | path }}">
 {% endblock %}
 
+{% block stylesheet_print %}
+  <link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-template-print.css' | path }}">
+{% endblock %}
+
 {% block logo_src %}
   {{ '/images/template/gov.uk_logotype_crown_invert_trans.png' | path }}
 {% endblock %}

--- a/src/components/_preview/_preview.njk
+++ b/src/components/_preview/_preview.njk
@@ -1,39 +1,22 @@
-<!DOCTYPE html>
-<html class="no-js">
-<head>
-  <meta charset="utf-8">
+{% extends "govuk_template.njk" %}
+
+{% block page_title %}
+  {{ _target.title }} &#9670; GOV.UK Frontend Alpha
+{% endblock %}
+
+{% block stylesheet %}
   <link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-frontend.css' | path }}">
-  <title>{{ _target.title }} &#9670; GOV.UK Frontend Alpha</title>
-  <script>
-  // govuk_template sets js-enabled
-  // we're not loading the template as a wrapper for components, so this class must be set in the preview template
-  document.documentElement.className = document.documentElement.className.replace('no-js', 'js-enabled');
-  </script>
-  <style>
-    html {
-      background-color: white;
-    }
-  </style>
-</head>
-<body>
-  {% if _target.context.setup.openWrapper %}
-    {{ _target.context.setup.openWrapper }}
-  {% endif %}
+{% endblock %}
 
+{% block content %}
   {{ yield }}
+{% endblock %}
 
-  {% if _target.context.setup.closeWrapper %}
-    {{ _target.context.setup.closeWrapper }}
-  {% endif %}
-</body>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-<script src="{{ '/javascripts/govuk-template.min.js' | path }}"></script>
-<script src="{{ '/javascripts/toolkit.min.js' | path }}"></script>
-<script src="{{ '/javascripts/components.min.js' | path }}"></script>
-<!-- TODO: Fix how this works, for now, initialise component js by updating initScript in the component's config file -->
-{% if _target.context.setup.initScript %}
-  <script>
-    {{ _target.context.setup.initScript }}
-  </script>
-{% endif %}
-</html>
+{% block scripts %}
+<!--[if gte IE 8]><!-->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+  <script src="{{ '/javascripts/govuk-template.min.js' | path }}"></script>
+  <script src="{{ '/javascripts/toolkit.min.js' | path }}"></script>
+  <script src="{{ '/javascripts/components.min.js' | path }}"></script>
+<!--<![endif]-->
+{% endblock %}

--- a/src/components/_preview/_preview.njk
+++ b/src/components/_preview/_preview.njk
@@ -8,6 +8,10 @@
   <link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-frontend.css' | path }}">
 {% endblock %}
 
+{% block logo_src %}
+  {{ '/images/template/gov.uk_logotype_crown_invert_trans.png' | path }}
+{% endblock %}
+
 {% block content %}
   {{ yield }}
 {% endblock %}

--- a/src/docs/04-template-blocks.md
+++ b/src/docs/04-template-blocks.md
@@ -5,7 +5,7 @@
 | top_of_page               | Before doctype                                  | Insertion point
 | html_lang                 | value of the HTML lang attribute                | en
 | page_title                | Text inside the `<title>` element               | GOV.UK - The best place to find government services and information
-| stylesheet                | The default stylesheet                          | <link href="stylesheets/govuk-frontend.css" media="screen" rel="stylesheet" />
+| stylesheet                | The default stylesheet                          | `<link href="stylesheets/govuk-frontend.css" media="screen" rel="stylesheet" />`
 | head                      | Before closing `</head>` element                | Insertion point
 | body_classes              | Classes to be added to the `<body>` element     | Insertion point
 | body_start                | After opening `<body>` element                  | Insertion point

--- a/src/templates/govuk_template.njk
+++ b/src/templates/govuk_template.njk
@@ -53,7 +53,9 @@
 
     {% block after_header %}{% endblock %}
 
+    {% block global_header_bar %}
     <div id="global-header-bar"></div>
+    {% endblock %}
 
     <div class="gv-o-wrapper">
       {% block phase_banner %}{% endblock %}
@@ -64,7 +66,7 @@
     </div>
 
 
-    <footer class="group js-footer" id="footer" role="contentinfo">
+    <footer class="{% block footer_class %}{% endblock %} group js-footer" id="footer" role="contentinfo">
 
       <div class="footer-wrapper">
         {% block footer_top %}{% endblock %}

--- a/src/templates/govuk_template.njk
+++ b/src/templates/govuk_template.njk
@@ -42,7 +42,7 @@
         <div class="header-global">
           <div class="header-logo">
             <a href="{{ homepage_url|default('https://www.gov.uk') }}" title="{{ logo_link_title|default('Go to the GOV.UK homepage') }}" id="logo" class="content">
-              <img src="{{ asset_path + 'images/template/gov.uk_logotype_crown_invert_trans.png' }}" width="35" height="31" alt=""> {{ global_header_text|default('GOV.UK') }}
+              <img src="{% block logo_src %}{{ asset_path + 'images/template/gov.uk_logotype_crown_invert_trans.png' }}{%endblock %}" width="35" height="31" alt=""> {{ global_header_text|default('GOV.UK') }}
             </a>
           </div>
           {% block inside_header %}{% endblock %}

--- a/src/templates/govuk_template.njk
+++ b/src/templates/govuk_template.njk
@@ -90,12 +90,14 @@
 
     <div id="global-app-error" class="app-error hidden"></div>
 
+    {% block scripts %}
     <!--[if gte IE 8]><!-->
       <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
       <script src="{{ asset_path + 'javascripts/govuk-template.min.js' }}"></script>
       <script src="{{ asset_path + 'javascripts/toolkit.min.js' }}"></script>
       <script src="{{ asset_path + 'javascripts/components.min.js' }}"></script>
     <!--<![endif]-->
+    {% endblock %}
 
     {% block body_end %}{% endblock %}
 

--- a/src/templates/govuk_template.njk
+++ b/src/templates/govuk_template.njk
@@ -7,7 +7,7 @@
     <title>{% block page_title %}GOV.UK - The best place to find government services and information{% endblock %}</title>
 
     {% block stylesheet %}<link href="{{ asset_path + 'stylesheets/govuk-frontend.css' }}" media="screen" rel="stylesheet" />{% endblock %}
-    <link href="{{ asset_path + 'stylesheets/govuk-template-print.css' }}" media="print" rel="stylesheet" />
+    {% block stylesheet_print %}<link href="{{ asset_path + 'stylesheets/govuk-template-print.css' }}" media="print" rel="stylesheet" />{% endblock %}
 
     <!--[if lte IE 8]><script src="{{ asset_path + 'javascripts/ie-shim.js' }}"></script><![endif]-->
 


### PR DESCRIPTION
#### What does it do?

This PR configures Fractal to find the `src/templates` directory, so that the preview layout (used to render a component) extends the govuk_template.njk layout file.

It then overrides template blocks for assets - stylesheets, scripts and images - and uses the [Nunjucks path filter](https://github.com/frctl/nunjucks#path), so each of the assets is found.

It also adds new blocks - where they didn't exist previously - to the template, for scripts and print styles. 

Since we don't want to show the GOV.UK header and footer for all component previews, it then adds additional blocks to the template, in order to override or hide blocks. 

There is a `header_class` block for the header, so a `footer_class` block was added to the footer to match - this enables the header and footer to be hidden. The blue header bar `#govuk-header-bar` must also be hidden, it was wrapped in a new block to allow it to be overridden in the preview template.

Lastly, it adds another preview template (not currently being used), which doesn't do any of the overridding or hiding, this will be useful when a component should be rendered with the GOV.UK layout - including header and footer.

#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply: -->
- New feature (non-breaking change which adds functionality)
