### PR TITLE
Display colour swatches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 public/
 npm-debug.log*
 lib/fractal/govuk-theme/assets/css/
+src/docs/07-colour/07-colour.config.json

--- a/lib/fractal/govuk-theme/assets/scss/_theme-elements.scss
+++ b/lib/fractal/govuk-theme/assets/scss/_theme-elements.scss
@@ -1,0 +1,45 @@
+// Mixins
+// ==========================================================================
+
+@mixin clearfix {
+  &::after {
+    display: block;
+    clear: both;
+    content: "";
+  }
+
+  @include ie-lte(7) {
+    zoom: 1;
+  }
+}
+
+
+// Swatches
+// ==========================================================================
+
+.swatch-section {
+  clear: both;
+  padding-top: 20px;
+}
+
+.swatch-wrapper {
+  width: 30%;
+  float: left;
+}
+
+.swatch {
+  width: 150px;
+  height: 60px;
+  margin-bottom: $gutter-half;
+}
+
+.swatch-scss {
+  @include core-16;
+}
+
+.swatch-hex  {
+  display: block;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+

--- a/lib/fractal/govuk-theme/assets/scss/fractal-govuk-theme.scss
+++ b/lib/fractal/govuk-theme/assets/scss/fractal-govuk-theme.scss
@@ -35,3 +35,5 @@ $desktop-breakpoint: 992px !default;
 // Override theme here
 @import "theme-settings";
 @import "theme-overrides";
+// Copied from GOV.UK elements
+@import "theme-elements";

--- a/lib/fractal/govuk-theme/views/macros/navigation.nunj
+++ b/lib/fractal/govuk-theme/views/macros/navigation.nunj
@@ -22,11 +22,13 @@
             {% else %}
             {% set items = item.filter('isHidden', false).items() %}
             {% endif %}
+            {% if item.isComponent %}
             <li class="Tree-item Tree-entity data-role="item">
                 <a class="Tree-entityLink" href="/components/detail/{{ item.handle }}" data-pjax>
-                    <span><b>Introduction</b></span>
+                    <span><b>Overview</b></span>
                 </a>
             </li>
+            {% endif %}
             {{ leaves(items, root, current, (depth + 1), request) }}
             </ul>
         </li>

--- a/lib/tasks/fractal-assets.js
+++ b/lib/tasks/fractal-assets.js
@@ -5,12 +5,16 @@ const paths = require('../../config/paths.json')
 const gulp = require('gulp')
 const sass = require('gulp-sass')
 
+const scssToJson = require('scss-to-json')
+const fs = require('fs')
+
 // This file provides the build tasks for the Fractal theme assets
 // To keep the "theme" assets separate, static assets can be found in /fractal/govuk-theme/
 // At present only the Sass is compiled to css, later tasks for scripts and image can be added.
 
 gulp.task('fractal:assets', [
-  'fractal:assets:styles'
+  'fractal:assets:styles',
+  'fractal:assets:colours'
   // TODO: 'fractal:theme:scripts',
   // TODO: 'fractal:theme:images'
 ])
@@ -24,6 +28,13 @@ gulp.task('fractal:assets:styles', () => {
      includePaths: [paths.fractalThemeScss + 'tech-docs-template']
    }).on('error', sass.logError))
     .pipe(gulp.dest(paths.fractalThemeCss))
+})
+
+// Colours - generate JSON from SCSS
+gulp.task('fractal:assets:colours', () => {
+  const filePath = paths.assetsScss + 'settings/_colours.scss'
+  const colorsJson = scssToJson(filePath)
+  fs.writeFileSync(paths.srcDocs + '07-colour/07-colour.config.json', JSON.stringify({ context: { colors: colorsJson } }), 'UTF-8')
 })
 
 // TODO: Scripts

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "phantomjs-prebuilt": "^2.1.13",
     "rollup-stream": "^1.14.0",
     "run-sequence": "^1.2.2",
+    "scss-to-json": "^1.1.0",
     "standard": "^8.6.0",
     "supertest": "^2.0.1",
     "through2": "^2.0.1",

--- a/src/docs/07-colour/index.md
+++ b/src/docs/07-colour/index.md
@@ -10,10 +10,19 @@ The colour contrast ratio for text and interactive elements should be at least 4
 Test your service to meet this standard.
 
 ### Sass variables
-
 Use Sass variables in case colour values need to be updated.
 
-### Extended palette
+<h3 class="swatch-section">Colours</h3>
 
-* used for graphs and supporting material
-* for tints of the extended palette use 50% or 25%
+{% for scss, hex in colors %}
+  <div class="swatch-wrapper">
+    <div class="swatch" style="background-color:{{ hex }};">
+    </div>
+    <b class="swatch-hex">
+      {{ hex }}
+    </b>
+    <p class="swatch-scss">
+      {{ scss }}
+    </p>
+  </div>
+{% endfor %}

--- a/src/docs/07-colour/index.md
+++ b/src/docs/07-colour/index.md
@@ -1,0 +1,19 @@
+---
+title: Colour
+context:
+  lede: Always use the GOV.UK colour palette.
+---
+
+### Colour contrast
+
+The colour contrast ratio for text and interactive elements should be at least 4.5:1 as recommended by the W3C.
+Test your service to meet this standard.
+
+### Sass variables
+
+Use Sass variables in case colour values need to be updated.
+
+### Extended palette
+
+* used for graphs and supporting material
+* for tints of the extended palette use 50% or 25%


### PR DESCRIPTION
#### What does it do?

This PR first makes a few set-up changes to the docs, renaming Introduction to Overview and hiding the "Introduction" section from the documentation, otherwise this appears when an item in the documentation exists in a directory within `/docs`.

It adds a section on colour, copied from GOV.UK elements and copies the styling for the theme swatches to the Fractal theme.

It generates a json context data file for the colour documentation and uses this to display colours from the `_colours.scss` file.

#### Screenshots (if appropriate):

![after](https://cloud.githubusercontent.com/assets/417754/23411663/e37817b8-fdca-11e6-8405-7044851ead75.png)


#### What type of change is it?
<!--- What types of changes does your code introduce? Delete the lines below that don't apply: -->
- New feature (non-breaking change which adds functionality)
