### PR TITLE
Improvements to fractal sidebar navigation

### DIFF
--- a/lib/fractal/govuk-theme/views/macros/navigation.nunj
+++ b/lib/fractal/govuk-theme/views/macros/navigation.nunj
@@ -11,7 +11,7 @@
 
 {% macro leaves(items, root, current, depth, request) %}
     {% for item in items %}
-        {% if item.isCollection or (item.isComponent and not item.isCollated and item.variants().filter('isHidden', false).size > 1) %}
+        {% if item.isCollection %}
         <li class="Tree-item Tree-collection Tree-depth-{{ depth }}" data-behaviour="collection" id="tree-{{ root.name }}-collection-{{ item.handle }}">
             <h4 class="Tree-collectionLabel" data-role="toggle">
                 <span>{{ item.label }}</span>

--- a/lib/fractal/govuk-theme/views/macros/navigation.nunj
+++ b/lib/fractal/govuk-theme/views/macros/navigation.nunj
@@ -12,7 +12,17 @@
 {% macro leaves(items, root, current, depth, request) %}
     {% for item in items %}
         {% if item.isCollection %}
+          {% if item.label == 'Layout' %}
+              </ul>
+            </div>
+          </div>
+          <div class="Navigation-group">
+            <div class="Tree" data-behaviour="tree" id="tree-styles">
+              <h3 class="Tree-title">Styles</h3>
+              <ul class="Tree-items Tree-depth-1">
+          {% endif %}
         <li class="Tree-item Tree-collection Tree-depth-{{ depth }}" data-behaviour="collection" id="tree-{{ root.name }}-collection-{{ item.handle }}">
+
             <h4 class="Tree-collectionLabel" data-role="toggle">
                 <span>{{ item.label }}</span>
             </h4>

--- a/lib/fractal/govuk-theme/views/macros/navigation.nunj
+++ b/lib/fractal/govuk-theme/views/macros/navigation.nunj
@@ -2,7 +2,7 @@
 
 {% macro tree(root, current, request) %}
 <div class="Tree" data-behaviour="tree" id="tree-{{ root.name }}">
-    <h3 class="Tree-title">{{ root.label }}</h3>
+    <h3 class="Tree-title">{{ root.title }}</h3>
     <ul class="Tree-items Tree-depth-1">
         {{ leaves(root.filter('isHidden', false).items(), root, current, 2, request) }}
     </ul>

--- a/lib/fractal/govuk-theme/views/macros/navigation.nunj
+++ b/lib/fractal/govuk-theme/views/macros/navigation.nunj
@@ -2,7 +2,7 @@
 
 {% macro tree(root, current, request) %}
 <div class="Tree" data-behaviour="tree" id="tree-{{ root.name }}">
-    <h3 class="Tree-title">{{ root.title }}</h3>
+    <h3 class="Tree-title">{{ root.label }}</h3>
     <ul class="Tree-items Tree-depth-1">
         {{ leaves(root.filter('isHidden', false).items(), root, current, 2, request) }}
     </ul>
@@ -22,20 +22,13 @@
             {% else %}
             {% set items = item.filter('isHidden', false).items() %}
             {% endif %}
-            {% if item.isComponent %}
-            <li class="Tree-item Tree-entity data-role="item">
-                <a class="Tree-entityLink" href="/components/detail/{{ item.handle }}" data-pjax>
-                    <span><b>Overview</b></span>
-                </a>
-            </li>
-            {% endif %}
             {{ leaves(items, root, current, (depth + 1), request) }}
             </ul>
         </li>
         {% else %}
         {% set isCurrent = true if (current and (current.id == item.id)) else false %}
         <li class="Tree-item Tree-entity{% if isCurrent %} is-current{% endif %}"{% if isCurrent %} data-state="current"{% endif %} data-role="item">
-            <a class="Tree-entityLink" href="{% if item.isDoc %}{{ path( (item | url), request) }}{% else %}/components/browser/{{ item.handle }}{% endif %}" data-pjax>
+            <a class="Tree-entityLink" href="{{ path( (item | url), request) }}" data-pjax>
                 <span>{{ item.label }}</span>
                 {% if item.status %}{{ status.unlabelled(item.status) }}{% endif %}
             </a>

--- a/lib/fractal/govuk-theme/views/pages/components/readme-only.nunj
+++ b/lib/fractal/govuk-theme/views/pages/components/readme-only.nunj
@@ -27,6 +27,14 @@
          {% else %}
           <p class="Browser-isEmptyNote">There are no notes for this item.</p>
          {% endif %}
+
+         <h2>Examples</h2>
+
+         <ul>
+         {% for variant in entity.variants().toArray() %}
+           <li><a href="/components/browser/{{ variant.handle }}">{{ variant.title }}</a></li>
+         {% endfor %}
+         </ul>
      </div>
     {% endblock %}
   </div>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

#### What does it do?
* Resets our customisations to the fractal navigation template.
* Breaks "styles" into it's own top level heading. This is done in a [very hacky and unmaintainable way](https://github.com/alphagov/govuk_frontend_alpha/commit/8ea0ec1d2a37f309a62f0f9aae6b73549944a346), how makes it work for user testing, to see if it's useful.
* Doesn't show component variants in a sub nav. Instead links to these from the bottom of the component overview/README. This can be moved above easily, to put it in the middle of the README is possible, but requires some additional work to avoid duplication.

#### Screenshots:
![image](https://cloud.githubusercontent.com/assets/63201/23615946/058173a4-0280-11e7-997c-ad4c9ad15923.png)