### PR TITLE
Add transpiler support for nesting blocks

### DIFF
--- a/lib/transpilation/transpiler.js
+++ b/lib/transpilation/transpiler.js
@@ -29,13 +29,17 @@ const transpileTemplate = (target, assetVersion) => {
     let template = file.contents.toString(encoding)
 
     for (let pattern of transpilationPatterns) {
-      template = template.replace(pattern.pattern, function (match, ...args) {
+      let transpileComponentCallback = (match, ...args) => {
         let replacement = match
         if (targetTranspiler[pattern.name] !== undefined) {
           replacement = pattern.replacer.call(null, targetTranspiler, ...args)
         }
         return replacement
-      })
+      }
+      let tmpTemplate
+      while (template !== (tmpTemplate = template.replace(pattern.pattern, transpileComponentCallback))) {
+        template = tmpTemplate
+      }
     }
 
     file.contents = new Buffer(template)

--- a/test/specs/transpiler_spec.js
+++ b/test/specs/transpiler_spec.js
@@ -20,6 +20,7 @@ const nunjucksAssetVersion = '1.0.0'
 const nunjucksTextFor = `<a href="#content" class="skiplink">{{ skip_link_message|default('Skip to main content') }}</a>`
 const nunjucksBlockFor = `{% block top_of_page %}{% endblock %}`
 const nunjucksBlockForWithAssetPath = `{% block stylesheets %}<link href="{{ asset_path + 'file.css' }}" />{% endblock %}`
+const nunjucksNestedBlock = `{% block outer %}{% block inner %}Default{% endblock %}{% endblock %}`
 
 describe('Transpilation', () => {
   it('should return a Buffer', function (done) {
@@ -92,6 +93,10 @@ describe('Transpilation', () => {
     it('should have a nested correct block_for with asset path inside', function (done) {
       const erbBlockForWithAssetPath = `<% if content_for?(:stylesheets) %><%= yield(:stylesheets) %><% else %><link href="<%= asset_path 'file.css?1.0.0' %>" /><% end %>`
       transpilationTest(erbTranspiler, nunjucksBlockForWithAssetPath, erbBlockForWithAssetPath, done)
+    })
+    it('should have a nested blocks', function (done) {
+      const erbNestedBlock = `<% if content_for?(:outer) %><%= yield(:outer) %><% else %><% if content_for?(:inner) %><%= yield(:inner) %><% else %>Default<% end %><% end %>`
+      transpilationTest(erbTranspiler, nunjucksNestedBlock, erbNestedBlock, done)
     })
   })
 


### PR DESCRIPTION
This relies on recursively applying the transpilation matchers. Only
really applies to blocks, as it doens't make sense to nest text or
assets.

Stop applying the matcher once the value no longer changes.

Only tested against ERB, as we're not really testing other langs during
the alpha.

If we wanted nested blocks beyond the alpha we should look at a more
robust approach like meta-template. This is intended to give us some
flexibility during alpha prototyping.

Related:
https://trello.com/c/HwEQlNbp/108-find-a-way-to-extend-the-govuk-template-inside-fractal

<!--- Provide a summary of your changes in the Title above -->

#### What does it do?
Allows the use of nested blocks within layout templates. Eg:

```
{% block outer %}
  {% block inner %}Default{% endblock %}
{% endblock %}
```

#### Screenshots (if appropriate):

#### What type of change is it?
- New feature (non-breaking change which adds functionality)
