### PR TITLE
Add parent blocks to the header and footer

### DIFF
--- a/src/components/_preview/_preview.njk
+++ b/src/components/_preview/_preview.njk
@@ -12,7 +12,8 @@
   <link media="all" rel="stylesheet" href="{{ '/stylesheets/govuk-template-print.css' | path }}">
 {% endblock %}
 
-{% block header_class %} hidden {% endblock %}
+{% block header %}
+{% endblock %}
 
 {% block after_header %}
   <style>
@@ -33,7 +34,8 @@
   {{ yield }}
 {% endblock %}
 
-{% block footer_class %} hidden {% endblock %}
+{% block footer %}
+{% endblock %}
 
 {% block scripts %}
 <!--[if gte IE 8]><!-->

--- a/src/docs/04-template-blocks.md
+++ b/src/docs/04-template-blocks.md
@@ -11,6 +11,7 @@
 | body_start                | After opening `<body>` element                  | Insertion point
 | skip_link_message         | Text inside the skip to main content link       | Skip to main content
 | cookie_message            | Text inside the cookie message banner           | `<p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>`
+| header                    | Block wraps the `<header>` element              | Insertion point
 | header_class              | `<header>` element                              | Set the value of header_class to [with-proposition](https://github.com/alphagov/govuk_template/blob/master/docs/usage.md#propositional-title-and-navigation) to show the propositional navigation
 | homepage_url              | URL of anchor element wrapping logo             | https://www.gov.uk/
 | logo_link_title           | Title of anchor element wrapping logo           | Go to the GOV.UK homepage
@@ -20,6 +21,8 @@
 | after_header              | After closing `</header>` element               | Insertion point
 | phase_banner              | Before the main content `<div>`                 | Insertion point
 | content                   | Main content goes in here                       | Insertion point. Content must be wrapped with `id="content"` for the [skiplink to work](docs/usage.md#skip-link).
+| footer                    | Block wraps the `<footer>` element              | Insertion point
+| footer_class              | `<footer>` element                              | Insertion point
 | footer_top                | Inside parent `#footer-wrapper`                 | Insertion point
 | footer_support_links      | Inside parent `.footer-meta-inner`              | Insertion point
 | licence_message           | Open Government Licence text and link           | `<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>`

--- a/src/templates/govuk_template.njk
+++ b/src/templates/govuk_template.njk
@@ -37,6 +37,7 @@
 
     <div id="global-cookie-message">{% block cookie_message %}{% endblock %}</div>
 
+    {% block header %}
     <header role="banner" id="global-header" class="{% block header_class %}{% endblock %}">
       <div class="header-wrapper">
         <div class="header-global">
@@ -50,6 +51,7 @@
         {% block proposition_header %}{% endblock %}
       </div>
     </header>
+    {% endblock %}
 
     {% block after_header %}{% endblock %}
 
@@ -66,6 +68,7 @@
     </div>
 
 
+    {% block footer %}
     <footer class="{% block footer_class %}{% endblock %} group js-footer" id="footer" role="contentinfo">
 
       <div class="footer-wrapper">
@@ -89,6 +92,7 @@
         </div>
       </div>
     </footer>
+    {% endblock %}
 
     <div id="global-app-error" class="app-error hidden"></div>
 

--- a/src/templates/unbranded_template.njk
+++ b/src/templates/unbranded_template.njk
@@ -40,6 +40,7 @@
     <div id="global-cookie-message">{% block cookie_message %}{% endblock %}</div>
 
 
+    {% block header %}
     <header role="banner" id="global-header" class="{% block header_class %}{% endblock %}">
       <div class="header-wrapper">
         <div class="header-global">
@@ -53,6 +54,7 @@
         {% block proposition_header %}{% endblock %}
       </div>
     </header>
+    {% endblock %}
 
     {% block after_header %}{% endblock %}
 
@@ -64,7 +66,9 @@
     </div>
     {% endblock %}
 
+    {% block footer %}
     <footer class="group js-footer" id="footer" role="contentinfo"></footer>
+    {% endblock %}
 
     <div id="global-app-error" class="app-error hidden"></div>
 


### PR DESCRIPTION
#### What does it do?

As the transpiler now supports nested blocks - add parent wrapping
blocks to the header and footer, to allow the entire block to be overridden as necessary.

This fixes the blocks that should be hidden in the preview layout. In #222 - a hidden class was added to the header_class and footer_class blocks, which wasn't ideal. Instead we can use the new parent blocks to override the header and footer in the preview layout.

I have also updated the Template blocks documentation.