### PR TITLE
Fix layout transpilation issues for ERB

### DIFF
--- a/lib/transpilation/transpiler.js
+++ b/lib/transpilation/transpiler.js
@@ -18,7 +18,9 @@ const transpileTemplate = (target, assetVersion) => {
     },
     {
       name: 'blockFor',
-      pattern: /\{% block (.*?) %\}(.*?)\{% endblock %\}/g,
+      // [^] allows matching across multiple lines, see:
+      // http://stackoverflow.com/questions/1068280/javascript-regex-multiline-flag-doesnt-work
+      pattern: /\{% block (.*?) %\}([^]*?)\{% endblock %\}/g,
       replacer: (transpiler, key, defaultContent) => transpiler.blockFor(key, defaultContent)
     }
   ]

--- a/src/templates/govuk_template.njk
+++ b/src/templates/govuk_template.njk
@@ -42,7 +42,7 @@
         <div class="header-global">
           <div class="header-logo">
             <a href="{{ homepage_url|default('https://www.gov.uk') }}" title="{{ logo_link_title|default('Go to the GOV.UK homepage') }}" id="logo" class="content">
-              <img src="{% block logo_src %}{{ asset_path + 'images/template/gov.uk_logotype_crown_invert_trans.png' }}{%endblock %}" width="35" height="31" alt=""> {{ global_header_text|default('GOV.UK') }}
+              <img src="{% block logo_src %}{{ asset_path + 'images/template/gov.uk_logotype_crown_invert_trans.png' }}{% endblock %}" width="35" height="31" alt=""> {{ global_header_text|default('GOV.UK') }}
             </a>
           </div>
           {% block inside_header %}{% endblock %}

--- a/test/specs/transpiler_spec.js
+++ b/test/specs/transpiler_spec.js
@@ -19,6 +19,8 @@ const nunjucksAssetPath = `<link href="{{ asset_path + 'stylesheets/govuk-templa
 const nunjucksAssetVersion = '1.0.0'
 const nunjucksTextFor = `<a href="#content" class="skiplink">{{ skip_link_message|default('Skip to main content') }}</a>`
 const nunjucksBlockFor = `{% block top_of_page %}{% endblock %}`
+const nunjucksBlockForWithContent = `{% block top_of_page %}Top of page default block content{% endblock %}`
+const nunjucksBlockForWithMultilineContent = `{% block top_of_page %}\nTop of page.\nDefault block content\n{% endblock %}`
 const nunjucksBlockForWithAssetPath = `{% block stylesheets %}<link href="{{ asset_path + 'file.css' }}" />{% endblock %}`
 const nunjucksNestedBlock = `{% block outer %}{% block inner %}Default{% endblock %}{% endblock %}`
 
@@ -49,6 +51,12 @@ describe('Transpilation', () => {
     })
     it('should have a correct block_for', function (done) {
       transpilationTest(nunjucksTranspiler, nunjucksBlockFor, nunjucksBlockFor, done)
+    })
+    it('should have a correct block_for with content', function (done) {
+      transpilationTest(nunjucksTranspiler, nunjucksBlockForWithContent, nunjucksBlockForWithContent, done)
+    })
+    it('should have a correct block_for with multiline content', function (done) {
+      transpilationTest(nunjucksTranspiler, nunjucksBlockForWithMultilineContent, nunjucksBlockForWithMultilineContent, done)
     })
     it('should have a nested correct block_for with asset path inside', function (done) {
       const transpiledBlockForWithAssetPath = `{% block stylesheets %}<link href="{{ asset_path }}file.css?1.0.0" />{% endblock %}`
@@ -84,6 +92,14 @@ describe('Transpilation', () => {
     it('should have a correct block_for', function (done) {
       const erbBlockFor = `<%= yield(:top_of_page) if content_for?(:top_of_page) %>`
       transpilationTest(erbTranspiler, nunjucksBlockFor, erbBlockFor, done)
+    })
+    it('should have a correct block_for with content', function (done) {
+      const erbBlockForWithContent = `<% if content_for?(:top_of_page) %><%= yield(:top_of_page) %><% else %>Top of page default block content<% end %>`
+      transpilationTest(erbTranspiler, nunjucksBlockForWithContent, erbBlockForWithContent, done)
+    })
+    it('should have a correct block_for with multiline content', function (done) {
+      const erbBlockForWithMultilineContent = `<% if content_for?(:top_of_page) %><%= yield(:top_of_page) %><% else %>\nTop of page.\nDefault block content\n<% end %>`
+      transpilationTest(erbTranspiler, nunjucksBlockForWithMultilineContent, erbBlockForWithMultilineContent, done)
     })
     it('should have a correct block_for for the special case content block', function (done) {
       const nunjucksContentBlockFor = `{% block content %}{% endblock %}`


### PR DESCRIPTION
Fix nunjucks tags leaking through to ERB output from transpilation.

#### What does it do?

Updates block transpilation to support multiline content, fixes a malformed nunjucks block.

#### What type of change is it?
- Bug fix (non-breaking change which fixes an issue)
